### PR TITLE
Shell now loads app.config relative to app base path

### DIFF
--- a/source/fitSharp/Machine/Application/Shell.cs
+++ b/source/fitSharp/Machine/Application/Shell.cs
@@ -73,7 +73,7 @@ namespace fitSharp.Machine.Application {
 
         void ParseArguments(IList<string> commandLineArguments) {
             var argumentParser = new ArgumentParser();
-            argumentParser.AddArgumentHandler("a", value => configuration.GetItem<AppDomainSetup>().ConfigurationFile = Path.GetFullPath(value));
+            argumentParser.AddArgumentHandler("a", value => configuration.GetItem<AppDomainSetup>().ConfigurationFile = value);
             argumentParser.AddArgumentHandler("c", value => new SuiteConfiguration(configuration).LoadXml(folderModel.FileContent(value)));
             argumentParser.AddArgumentHandler("r", value => configuration.GetItem<Settings>().Runner = value);
             argumentParser.SetUnusedHandler(value => extraArguments.Add(value));

--- a/source/fitSharpTest/NUnit/Machine/ShellTest.cs
+++ b/source/fitSharpTest/NUnit/Machine/ShellTest.cs
@@ -14,6 +14,20 @@ using NUnit.Framework;
 using Configuration=fitSharp.Machine.Engine.Configuration;
 
 namespace fitSharp.Test.NUnit.Machine {
+
+    class PushCurrentDirectory : IDisposable {
+        string original;
+
+        public PushCurrentDirectory(string directory) {
+            original = Environment.CurrentDirectory;
+            Environment.CurrentDirectory = directory;
+        }
+
+        public void Dispose() {
+            Environment.CurrentDirectory = original;
+        }
+    }
+
     [TestFixture] public class ShellTest {
         [Test] public void RunnerIsCalled() {
             int result = RunShell(new [] {"-r", typeof(SampleRunner).FullName});
@@ -29,8 +43,14 @@ namespace fitSharp.Test.NUnit.Machine {
 
         [Test] public void CustomAppConfigIsUsed() {
             int result = RunShell(new[] {"-a", "fitSharpTest.dll.alt.config",
-                "-r", typeof (SampleRunner).FullName + "," + typeof (SampleRunner).Assembly.CodeBase} );
+                "-r", typeof (SampleRunner).FullName + "," + typeof (SampleRunner).Assembly.CodeBase});
             Assert.AreEqual(606, result);
+        }
+
+        [Test] public void CustomAppConfigIsLoadedRelativeToExecutingAssembly() {
+            using (new PushCurrentDirectory(@"\")) {
+                CustomAppConfigIsUsed();
+            }
         }
 
         [Test] public void CustomAppConfigFromSuiteConfigIsUsed() {


### PR DESCRIPTION
Shell now loads app.config relative to app base path instead of current directory.

By passing the appconfig path unadorned to AppDomainSetup, we get normal .NET behavior, where appconfig is loaded relative to the base path, which allows us to run tests from a current directory other than where Runner.exe is.
