### PR TITLE
Ignores any failures if configured assembly does not exist.

### DIFF
--- a/source/fitSharp/Machine/Engine/ApplicationUnderTest.cs
+++ b/source/fitSharp/Machine/Engine/ApplicationUnderTest.cs
@@ -119,9 +119,31 @@ namespace fitSharp.Machine.Engine {
             public void AddAssembly(string assemblyName) {
                 if (IsIgnored(assemblyName)) return;
                 if (assemblies.Exists(a => a.Name == assemblyName)) return;
+                if (!AssemblyFileExists(assemblyName)) return;
+
                 var assembly = appDomain.LoadAssembly(assemblyName);
+
                 if (assemblies.Exists(a => a.Name == assembly.Name)) return;
                 assemblies.Add(assembly);
+            }
+
+            private bool AssemblyFileExists(string assemblyName) {
+                // Could be either of the forms:
+                //  file:///C:\foo\bar\bob.dll
+                //  bob.dll
+                //  C:\foo\bar\bob.dll
+                //  \bob.dll
+
+                string assemblyFileName = NormalizeAssemblyFileName(assemblyName);
+                return File.Exists(assemblyFileName);
+            }
+
+            private string NormalizeAssemblyFileName(string assemblyName) {
+                string assemblyFileName = assemblyName;
+                if (assemblyName.StartsWith("file:"))
+                    assemblyFileName = new Uri(assemblyName).AbsolutePath;
+
+                return Path.GetFullPath(assemblyFileName);
             }
 
             static bool IsIgnored(string assemblyName) {

--- a/source/fitSharpTest/NUnit/Machine/ApplicationUnderTestTest.cs
+++ b/source/fitSharpTest/NUnit/Machine/ApplicationUnderTestTest.cs
@@ -109,6 +109,11 @@ namespace fitSharp.Test.NUnit.Machine {
             domain.VerifyAll();
         }
 
+        [Test] public void MissingAssembliesAreIgnored() {
+            applicationUnderTest.AddAssembly("I_do_not_exist.dll");
+            Assert.Pass("AddAssembly should not throw if file does not exist.");
+        }
+
         void CheckTypeFound<T>(string typeName) {
             RuntimeType sample = GetType(typeName);
             Assert.AreEqual(typeof(T), sample.Type);


### PR DESCRIPTION
This is important to us, because parts of our suite needs to run with a different current working directory than others, so we have conflicting AddAssembly directives in suite.config

  &lt;ApplicationUnderTest&gt;
    &lt;!-- these two are the same assembly, but only one of them will load depending on current working directory --&gt;
    &lt;AddAssembly&gt;fixtures.dll&lt;/AddAssembly&gt;
    &lt;AddAssembly&gt;........\bin\fixtures.dll&lt;/AddAssembly&gt;
  &lt;/ApplicationUnderTest&gt;

FitNesse.NET allowed this construct (see [1]), so it would be nice if it could carry over to fitSharp, even if it's a little dirty.

[1] http://fitnessedotnet.svn.sourceforge.net/viewvc/fitnessedotnet/trunk/src/fit/Assemblies.cs?revision=180&view=markup line 49
