### PR TITLE
Currently executing page exposed to fixtures

### DIFF
--- a/source/fit/Runner/SuiteRunner.cs
+++ b/source/fit/Runner/SuiteRunner.cs
@@ -90,6 +90,9 @@ namespace fit.Runner {
                     page.WriteNonTest();
                     DoNoTest();
                 }
+
+                StoreCurrentlyExecutingPagePath(page.Name.Name);
+
 	            var service = new Service.Service(memory);
 	            Tree<Cell> result = service.Compose(new StoryTestString(input));
 	            if (result == null || result.Branches.Count == 0) {
@@ -97,6 +100,7 @@ namespace fit.Runner {
                     DoNoTest();
 	                return;
 	            }
+
                 var writer = new StoryTestStringWriter(service);
                 var storyTest = new StoryTest((Parse) result, writer);
                 if (page.Name.IsSuitePage) {
@@ -113,6 +117,10 @@ namespace fit.Runner {
 
             public void DoNoTest() {
                 handleCounts(new TestCounts());
+            }
+
+            private void StoreCurrentlyExecutingPagePath(string path) {
+                memory.GetItem<Context>().TestPagePath = path;
             }
 
             readonly ResultWriter resultWriter;

--- a/source/fitTest/NUnit/FixtureNUnitTest.cs
+++ b/source/fitTest/NUnit/FixtureNUnitTest.cs
@@ -4,7 +4,9 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 using fitSharp.Fit.Service;
+using fitSharp.Fit.Model;
 using NUnit.Framework;
+using fitSharp.Machine.Application;
 
 namespace fit.Test.NUnit {
     [TestFixture]
@@ -60,6 +62,28 @@ namespace fit.Test.NUnit {
             Assert.AreEqual("&lt;&amp;&lt;", Fixture.Escape("<&<"));
             Assert.AreEqual("&amp;&lt;&amp;", Fixture.Escape("&<&"));
             Assert.AreEqual("a &lt; b &amp;&amp; c &lt; d", Fixture.Escape("a < b && c < d"));
+        }
+    }
+
+    [TestFixture]
+    public class ContextTest {
+        private Fixture fixture;
+        private CellProcessorBase processor;
+
+        [SetUp]
+        public void SetUp() {
+            processor = new CellProcessorBase();
+            processor.Memory.GetItem<Context>().TestPagePath = @"\some\path.html";
+
+            fixture = new Fixture { Processor = processor };
+        }
+
+        [Test]
+        public void TestProcessorContextDataIsExposedToFixture() {
+            // I admit this test is a little forced, but I have another test verifying that
+            // the context is populated by SuiteRunner, so it makes sense to test
+            // that the fixture sees the change, too. To me, anyway.
+            Assert.AreEqual(@"\some\path.html", fixture.Processor.Get<Context>().TestPagePath);
         }
     }
 

--- a/source/fitTest/NUnit/SuiteRunnerTest.cs
+++ b/source/fitTest/NUnit/SuiteRunnerTest.cs
@@ -94,6 +94,16 @@ namespace fit.Test.NUnit {
             Assert.IsEmpty(folders.GetFolders("out"));
         }
 
+        [Test]
+        public void TestPagePathIsStoredInMemoryWhenPageExecutes() {
+            Assert.IsNullOrEmpty(memory.GetItem<Context>().TestPagePath);
+
+            AddTestFile(@"in\page.html");
+            RunSuite();
+
+            Assert.AreEqual(@"in\page.html", memory.GetItem<Context>().TestPagePath);
+        }
+
         private void RunSuite() {
             RunSuite(new NullReporter());
         }


### PR DESCRIPTION
Currently executing page path is now exposed to fixtures through Processor.Memory.
