### PR TITLE
Lookup Fixture for keywords before trying FlowKeywords

### DIFF
--- a/source/fitSharp/Fit/Operators/InvokeSpecialAction.cs
+++ b/source/fitSharp/Fit/Operators/InvokeSpecialAction.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2012 Syterra Software Inc. All rights reserved.
+// Copyright © 2012 Syterra Software Inc. All rights reserved.
 // The use and distribution terms for this software are covered by the Common Public License 1.0 (http://opensource.org/licenses/cpl.php)
 // which can be found in the file license.txt at the root of this distribution. By using this software in any fashion, you are agreeing
 // to be bound by the terms of this license. You must not remove this notice, or any other, from this software.
@@ -19,16 +19,23 @@ namespace fitSharp.Fit.Operators {
         public TypedValue Invoke(TypedValue instance, MemberName memberName, Tree<Cell> parameters) {
             var type = Processor.ApplicationUnderTest.FindType("fit.Parse").Type;
 
-            var runtimeType = Processor.ApplicationUnderTest.FindType("fit.Fixtures.FlowKeywords");
-            var runtimeMember = runtimeType.GetConstructor(2);
-            var flowKeywords = runtimeMember.Invoke(new [] {instance.Value, Processor});
-            foreach (var member in FindMember(flowKeywords, memberName, type).Value) {
-                return member.Invoke(new object[] {parameters.Value});
+    		// lookup Fixture
+			foreach (var member in FindMember(instance, memberName, type).Value)
+			{
+                return member.Invoke(new object[] { parameters.Value });
             }
 
-            return FindMember(instance, memberName, type).ForValue(
-                            member => member.Invoke(new object[] {parameters.Value}),
-                            () => TypedValue.MakeInvalid(new MemberMissingException(instance.Type, memberName.Name, 1)));
+			// lookup FlowKeywords
+			var runtimeType = Processor.ApplicationUnderTest.FindType("fit.Fixtures.FlowKeywords");
+			var runtimeMember = runtimeType.GetConstructor(2);
+			var flowKeywords = runtimeMember.Invoke(new[] { instance.Value, Processor });
+
+			foreach (var member in FindMember(flowKeywords, memberName, type).Value)
+			{
+				return member.Invoke(new object[] { parameters.Value });
+			}
+			
+			return TypedValue.MakeInvalid(new MemberMissingException(instance.Type, memberName.Name, 1));
         }
 
         static Maybe<RuntimeMember> FindMember(TypedValue flowKeywords, MemberName memberName, Type type) {


### PR DESCRIPTION
Okay, here is a pull request for solving my issue jediwhale/fitsharp#96. I got it working, but then I realized that the solution was not what I was looking for. Finally I overrode `DoTable()` and removed the `InvokeSpecialAction` operator.

However, I wanted to share my solution with you, because I think it is still reasonable.
