### PR TITLE
Corrected test failures on fresh clone

### DIFF
--- a/source/TestTarget/TestTarget.csproj
+++ b/source/TestTarget/TestTarget.csproj
@@ -50,6 +50,8 @@
   </Target>
   -->
   <PropertyGroup>
-    <PostBuildEvent>xcopy "$(TargetPath)*" "$(SolutionDir)build\$(ConfigurationName)\" /I /Y</PostBuildEvent>
+    <PostBuildEvent>xcopy "$(TargetPath)*" "$(SolutionDir)build\$(ConfigurationName)\" /I /Y
+xcopy "$(TargetPath)*" "$(SolutionDir)source\fitSharpTest\bin\$(ConfigurationName)\" /I /Y
+</PostBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Added an additional post-build event command line to copy the
TestTarget.dll to the fitSharpTests build output folder. This corrects 2
test failures that occur when attempting to run the tests with ReSharper
in a fresh clone of the repo.
