### PR TITLE
Allow Release builds with the build command.

### DIFF
--- a/abandonsuite.config.xml
+++ b/abandonsuite.config.xml
@@ -5,7 +5,7 @@
     </Settings>
     
     <ApplicationUnderTest>
-        <addAssembly>build\debug\fittest.dll</addAssembly>
+        <addAssembly>build\sandbox\fittest.dll</addAssembly>
         <addNamespace>fit.Test.Double</addNamespace>
     </ApplicationUnderTest>
     

--- a/build.proj
+++ b/build.proj
@@ -16,17 +16,30 @@
         Properties="Configuration=$(Config)" />
 </Target>
 
-<Target Name="unittests">
-    <Exec Command="binary\tools\nunit\nunit-console -nologo -framework:net-4.0 .\build\$(Config)\fitSharpTest.dll" />
-    <Exec Command="binary\tools\nunit\nunit-console -nologo -framework:net-4.0 .\build\$(Config)\fitTest.dll" />
+<!-- Set up a sandbox with a fixed name that story test pages
+     and configurations can refer to. -->
+<Target Name="sandbox" DependsOnTargets="solution">
+    <ItemGroup>
+        <Assemblies Include="build\$(Config)\**\*"/>
+    </ItemGroup>
+
+    <Copy
+        SourceFiles="@(Assemblies)"
+        DestinationFolder="build\sandbox\%(Assemblies.RecursiveDir)"
+    />
 </Target>
 
-<Target Name="storytests">
-    <Exec Command=".\build\debug\runner -c storytest.config.xml" />
+<Target Name="unittests" DependsOnTargets="sandbox">
+    <Exec Command="binary\tools\nunit\nunit-console -nologo -framework:net-4.0 .\build\sandbox\fitSharpTest.dll" />
+    <Exec Command="binary\tools\nunit\nunit-console -nologo -framework:net-4.0 .\build\sandbox\fitTest.dll" />
+</Target>
+
+<Target Name="storytests" DependsOnTargets="sandbox">
+    <Exec Command=".\build\sandbox\runner -c storytest.config.xml" />
 </Target>
 
 <Target Name="dbfittests">
-    <Exec Command="binary\tools\nunit\nunit-console -nologo .\build\$(Config)\dbfitTest.dll" />
+    <Exec Command="binary\tools\nunit\nunit-console -nologo .\build\sandbox\dbfitTest.dll" />
     <Exec Command="java -jar \apps\fitnesse\fitnesse.jar -o -d .\document -r FitNesseRoot -c &quot;DbFitTests?suite&amp;format=text&quot;" />
 </Target>
 

--- a/dbfit.config.xml
+++ b/dbfit.config.xml
@@ -1,9 +1,9 @@
 <suiteConfig>
 
     <ApplicationUnderTest>
-        <addAssembly>build\debug\dbfit.dll</addAssembly>
-        <addAssembly>build\debug\dbfit.sqlserver.dll</addAssembly>
-        <addAssembly>build\debug\dbfit.mysql.dll</addAssembly>
+        <addAssembly>build\sandbox\dbfit.dll</addAssembly>
+        <addAssembly>build\sandbox\dbfit.sqlserver.dll</addAssembly>
+        <addAssembly>build\sandbox\dbfit.mysql.dll</addAssembly>
         <addNamespace>dbfit.fixture</addNamespace>
     </ApplicationUnderTest>
     

--- a/document/FitnesseRoot/AbandonSuite/content.txt
+++ b/document/FitnesseRoot/AbandonSuite/content.txt
@@ -1,4 +1,4 @@
-!define TEST_RUNNER {build\debug\Runner.exe}
+!define TEST_RUNNER {build\sandbox\Runner.exe}
 !define COMMAND_PATTERN {%m -c abandonsuite.config.xml %p}
 
 !contents

--- a/document/FitnesseRoot/DbFitTests/content.txt
+++ b/document/FitnesseRoot/DbFitTests/content.txt
@@ -1,4 +1,4 @@
-!define TEST_RUNNER {build\debug\Runner.exe}
+!define TEST_RUNNER {build\sandbox\Runner.exe}
 !define COMMAND_PATTERN {%m -r fitnesse.fitserver.FitServer -c dbfit.config.xml %p}
 
 !contents

--- a/document/fitSharp/Fit/ObjectFactoryTest.html
+++ b/document/fitSharp/Fit/ObjectFactoryTest.html
@@ -22,7 +22,7 @@ to be bound by the terms of this license. You must not remove this notice, or an
 A fixture is created from a loaded assembly.<br>
 <table border="1" cellpadding="2" cellspacing="0">
 <tr><td>configure</td><td>applicationundertest</td></tr>
-<tr><td>add assembly</td><td>build\debug\testTarget.dll</td></tr>
+<tr><td>add assembly</td><td>build\sandbox\testTarget.dll</td></tr>
 <tr><td>add namespace</td><td>fitSharp.TestTarget</td></tr>
 </table>
 <br>
@@ -32,7 +32,7 @@ A fixture is created from a loaded assembly.<br>
 <br>
 A duplicate copy of an assembly is ignored.<br>
 <table border="1" cellpadding="2" cellspacing="0">
-<tr><td>add copy of assembly</td><td>build\debug\testTarget.dll</td></tr>
+<tr><td>add copy of assembly</td><td>build\sandbox\testTarget.dll</td></tr>
 <tr><td>check</td><td>create instance</td><td>sampletargettype</td><td>fitSharp.TestTarget.SampleTargetType</td></tr>
 </table>
 </div>

--- a/storytest.config.xml
+++ b/storytest.config.xml
@@ -21,9 +21,9 @@
         <addNamespace>fitlibrary</addNamespace>
         <addNamespace>fit.Fixtures</addNamespace>
         <addNamespace>fitSharp.Test.Acceptance.Slim</addNamespace>
-        <addAssembly>build\debug\fitsharptest.dll</addAssembly>
-        <addAssembly>build\debug\fittest.dll</addAssembly>
-        <addAssembly>build\debug\samples.dll</addAssembly>
+        <addAssembly>build\sandbox\fitsharptest.dll</addAssembly>
+        <addAssembly>build\sandbox\fittest.dll</addAssembly>
+        <addAssembly>build\sandbox\samples.dll</addAssembly>
     </ApplicationUnderTest>
     
     <Culture>


### PR DESCRIPTION
- build.proj sets the current working dir to build/$(Config)
- storytest.config.xml paths rebased per the above
- All affected test pages rebased per the above
- Net result: uglier test pages, but you can do:
  $ build "/p:Config=Release"
  and have build, unittest and storytest happen
  on the built release binaries.

The main effect is that fitsharp's own story tests now assume they run from the directory of the Runner binary, e.g. build/debug or build/release, not from the fitsharp root directory.

I'm sure there are more principled ways of doing this, but I just want to get a consistent build procedure in place. Does this update make sense?
