### PR TITLE
Adding AddOperatorFirst to Processor interface so that it can be called from fixtures

### DIFF
--- a/source/fitSharp/Machine/Engine/Processor.cs
+++ b/source/fitSharp/Machine/Engine/Processor.cs
@@ -16,6 +16,7 @@ namespace fitSharp.Machine.Engine {
         void AddNamespace(string namespaceName);
 
         void AddOperator(string operatorName);
+        void AddOperatorFirst(string operatorName);
         void RemoveOperator(string operatorName);
 
         bool Compare(TypedValue instance, Tree<T> parameters);


### PR DESCRIPTION
Mike,

AddOperatorFirst was added to Operators in commit 0f4b5f44 but was not added to the Processor interface, which meant that it couldn't be called from the Processor property of fit.Fixture.

I added it to the interface.

Matthew
