### PR TITLE
Adding AddOperatorFirst to Processor interface so that it can be called from fixtures

### DIFF
--- a/source/fitSharp/Machine/Engine/Processor.cs
+++ b/source/fitSharp/Machine/Engine/Processor.cs
@@ -16,6 +16,7 @@ namespace fitSharp.Machine.Engine {
         void AddNamespace(string namespaceName);
 
         void AddOperator(string operatorName);
+        void AddOperatorFirst(string operatorName);
         void RemoveOperator(string operatorName);
 
         bool Compare(TypedValue instance, Tree<T> parameters);


### PR DESCRIPTION
Here is another pull request on a different branch. Github wouldn't let me create another pull request on master.

I'm sorry for the trouble, Kim. I'll ask Mike to delete the other one.
