### PR TITLE
Get rid of compiler warnings.

### DIFF
--- a/source/fitSharpTest/NUnit/Fit/BindingFactoryTest.cs
+++ b/source/fitSharpTest/NUnit/Fit/BindingFactoryTest.cs
@@ -49,7 +49,7 @@ namespace fitSharp.Test.NUnit.Fit {
         }
 
         class TestTarget: TargetObjectProvider {
-            public string NewMember;
+            public string NewMember = null;
             public object GetTargetObject() { return this; }
         }
     }

--- a/source/fitTest/NUnit/FixtureNUnitTest.cs
+++ b/source/fitTest/NUnit/FixtureNUnitTest.cs
@@ -90,6 +90,10 @@ namespace fit.Test.NUnit {
         }
     }
 
+// Disable the Obsolete warning, we want to run these
+// tests until we remove the Save/Recall methods entirely.
+#pragma warning disable 612, 618
+
     [TestFixture]
     public class SaveAndRecallTest
     {
@@ -140,4 +144,6 @@ namespace fit.Test.NUnit {
             Assert.AreSame(fixture, fixture.GetTargetObject());
         }
     }
+
+#pragma warning restore 612, 618
 }


### PR DESCRIPTION
Minor changes to silence compiler warnings:
- Locally disable Obsolete warnings, we're testing this until the Obsolete methods disappear
- Initialize public member only used via reflection

This makes it way easier to see if we introduce new warning noise.