### PR TITLE
SqlServer Time-Type

### DIFF
--- a/source/dbfitSqlServer/SqlServerEnvironment.cs
+++ b/source/dbfitSqlServer/SqlServerEnvironment.cs
@@ -214,7 +214,7 @@ namespace dbfit
             if (Array.IndexOf(VariantTypes, dataType) >= 0) return typeof(string);
             if (Array.IndexOf(FloatTypes, dataType) >= 0) return typeof(double);
             if (Array.IndexOf(RealTypes, dataType) >= 0) return typeof(float);
-            if (Array.IndexOf(TimeTypes, dataType) >= 0) return typeof(DateTime);
+            if (Array.IndexOf(TimeTypes, dataType) >= 0) return typeof(TimeSpan);
 
 
             throw new NotSupportedException(".net Type " + dataType + " is not supported");


### PR DESCRIPTION
In Function "GetDotNetType" the returned DotNetType for Time-Type in
SqlServer is not "DateTime" but "TimeSpan".

The following test fails:

!|Execute|!-DELETE FROM dbo.TimeTable;-!|
|Commit|

!|Insert|dbo.TimeTable|
|TimeCol|
|06:00:00|
|12:00:00|
|Commit|

!|Ordered Query|Select * from dbo.TimeTable|
|TimeCol?|
|06:00:00|
|12:00:00|

System.InvalidCastException: Parameterwert konnte nicht von DateTime in
TimeSpan umgewandelt werden. ---> System.InvalidCastException: Ungültige
Umwandlung von "System.DateTime" in "System.TimeSpan".
bei System.Convert.DefaultToType(IConvertible value, Type targetType,
IFormatProvider provider)
bei System.DateTime.System.IConvertible.ToType(Type type,
IFormatProvider provider)
bei System.Convert.ChangeType(Object value, Type conversionType,
IFormatProvider provider)
bei System.Data.SqlClient.SqlParameter.CoerceValue(Object value,
MetaType destinationType, Boolean& coercedToDataFeed, Boolean&
typeChanged, Boolean allowStreaming)
--- Ende der internen Ausnahmestapelüberwachung ---
bei System.Data.SqlClient.SqlParameter.CoerceValue(Object value,
MetaType destinationType, Boolean& coercedToDataFeed, Boolean&
typeChanged, Boolean allowStreaming)
bei System.Data.SqlClient.SqlParameter.GetCoercedValue()
bei System.Data.SqlClient.SqlParameter.Validate(Int32 index, Boolean
isCommandProc)
bei System.Data.SqlClient.SqlCommand.BuildParamList(TdsParser parser,
SqlParameterCollection parameters)
bei System.Data.SqlClient.SqlCommand.BuildExecuteSql(CommandBehavior
behavior, String commandText, SqlParameterCollection parameters,
_SqlRPC& rpc)
bei System.Data.SqlClient.SqlCommand.RunExecuteReaderTds(CommandBehavior
cmdBehavior, RunBehavior runBehavior, Boolean returnStream, Boolean
async, Int32 timeout, Task& task, Boolean asyncWrite, SqlDataReader ds)
bei System.Data.SqlClient.SqlCommand.RunExecuteReader(CommandBehavior
cmdBehavior, RunBehavior runBehavior, Boolean returnStream, String
method, TaskCompletionSource`1 completion, Int32 timeout, Task& task,
Boolean asyncWrite)
bei
System.Data.SqlClient.SqlCommand.InternalExecuteNonQuery(TaskCompletionSource`1
completion, String methodName, Boolean sendToPipe, Int32 timeout,
Boolean asyncWrite)
bei System.Data.SqlClient.SqlCommand.ExecuteNonQuery()
bei fit.ColumnFixture.DoRow(Parse row)