### PR TITLE
Allow Connection To DB via config file

### DIFF
--- a/source/dbfit/dbfit.csproj
+++ b/source/dbfit/dbfit.csproj
@@ -32,6 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />

--- a/source/dbfit/environment/DbEnvironment.cs
+++ b/source/dbfit/environment/DbEnvironment.cs
@@ -1,43 +1,49 @@
+using fitSharp.Machine.Engine;
+
 /// Copyright (C) Gojko Adzic 2006-2008 http://gojko.net
 /// Released under GNU GPL 2.0
 using System;
 using System.Collections.Generic;
-using System.Data.Common;
 using System.Data;
-using fitSharp.Machine.Engine;
+using System.Data.Common;
 
-namespace dbfit {
+namespace dbfit
+{
     /// <summary>
     /// IDbEnvironment provides a common interface for database-specific meta-data retrieval
     /// and operations. IDbEnvironment instances encapculate all database-specific functionality,
     /// so that DbFit fixtures can be database-neutral. IDbEnvironment instances are also
     /// responsible for transaction management.
     /// </summary>
-	public interface IDbEnvironment {
+    public interface IDbEnvironment
+    {
         /// <summary>
         /// Retrieves an instance of DbProviderFactory class that can be used
         /// to create database-specific implementations of database parameters,
         /// data-set readers etc
         /// </summary>
-        DbProviderFactory DbProviderFactory { get ; }
+        DbProviderFactory DbProviderFactory { get; }
+
         /// <summary>
         /// A flag to signal whether the database supports output parameters on insert commands,
         /// or whether the auto-generated identity values have to be retrieved with a separate
         /// statement after insert.
         /// </summary>
-	    bool SupportsReturnOnInsert { get ;}
+        bool SupportsReturnOnInsert { get; }
+
         /// <summary>
         /// If the database requires an additional statement to fetch auto-generated identity values passing the table name,
         /// this property is used as the select query to execute that statement.
         /// </summary>
         String IdentitySelectStatement(String tableName);
+
         /// <summary>
         /// Meta-data retrieval method that provides a list of parameters for a given stored procedure
         /// or function name. The name may contain a schema qualifier.
         /// </summary>
         /// <param name="procName">name of the procedure or function to look up in the database</param>
         /// <returns>a map of parameter names to DbParameterAccessor objects for procedure parameters</returns>
-    	Dictionary<string, DbParameterAccessor> GetAllProcedureParameters(string procName);
+        Dictionary<string, DbParameterAccessor> GetAllProcedureParameters(string procName);
 
         /// <summary>
         /// Meta-data retrieval method that provides a list of columns a given stored table
@@ -45,8 +51,9 @@ namespace dbfit {
         /// </summary>
         /// <param name="procName">name of the table or view to look up in the database</param>
         /// <returns>a map of column names to DbParameterAccessor objects for table columns</returns>
-    	
-		Dictionary<string, DbParameterAccessor> GetAllColumns(string tableOrViewName);
+
+        Dictionary<string, DbParameterAccessor> GetAllColumns(string tableOrViewName);
+
         /// <summary>
         /// This method creates an insert command that will be used to populate new rows in a table
         /// </summary>
@@ -54,51 +61,54 @@ namespace dbfit {
         /// <param name="accessors">list of columns that will be used in the insert command</param>
         /// <returns>Command string in the appropriate form, with parameter placeholders</returns>
         String BuildInsertCommand(String tableName, DbParameterAccessor[] accessors);
+
         /// <summary>
         ///  This method should create and initialise a DbCommand object based on the current
-        /// IDbEnvironment connection and transaction. 
+        /// IDbEnvironment connection and transaction.
         /// </summary>
         /// <param name="statement">Command text to execute</param>
         /// <param name="commandType">Statement type</param>
         /// <returns>initialised DbCommand object</returns>
         DbCommand CreateCommand(string statement, CommandType commandType);
+
         /// <summary>
         /// Closes the current connection and rolls back any active transactions. The transactions
         /// are automatically rolled back to make tests repeatable.
         /// </summary>
         void CloseConnection();
+
         /// <summary>
         /// Connects to the database using a default database for the user
         /// </summary>
         /// <param name="dataSource">Host (optionally port), machine name or any other data source identifier</param>
         void Connect(String dataSource, String username, String password);
-        
+
         /// <summary>
         /// Connects to the database using a specified database for the user
         /// </summary>
         /// <param name="dataSource">Host (optionally port), machine name or any other data source identifier</param>
         /// <param name="database">default database after connection</param>
         void Connect(String dataSource, String username, String password, String database);
-        
+
         /// <summary>
         /// Connects using a database-specific connection string. This allows users to specify
         /// parameters that would not be used otherwise (i.e. windows integrated security)
         /// </summary>
         /// <param name="connectionString">full ADO.NET connection string</param>
-    	void Connect(String connectionString);
-        
+        void Connect(String connectionString);
+
         /// <summary>
         /// Load database properties from a file and connect.
         /// The connection properties file is a plain text file, containing key/value pairs separarted by the equals symbol (=). Lines starting with a hash (#) are ignored. Use the following keys (they care case-sensitive):
-        /// 
+        ///
         /// 1. service -- service name. In the previous example, it was LAPTOP\SQLEXPRESS.
         /// 2. username -- username to connect to the database. In the previous example, it was FitNesseUser.
         /// 3. password -- password to connect to the database. In the previous example, it was Password.
         /// 4. database -- optional fourth argument, allowing you to choose the active database. In the previous example, it was TestDB.
-        /// 5. connection-string -- alternative to the four previous parameters, this allows you to specify the full connection string. This parameter should not be mixed with any of the four other keys. Use either the full string or specify individual properties. 
-        /// 
+        /// 5. connection-string -- alternative to the four previous parameters, this allows you to specify the full connection string. This parameter should not be mixed with any of the four other keys. Use either the full string or specify individual properties.
+        ///
         /// Here is an example:
-        /// 
+        ///
         /// # DBFit connection properties file
         /// #
         /// #1) Either specify full connection string
@@ -115,6 +125,15 @@ namespace dbfit {
         void ConnectUsingFile(String connectionPropertiesFile);
 
         /// <summary>
+        /// Connects using a database-specific connection string. This allows users to specify
+        /// parameters that would not be used otherwise (i.e. windows integrated security)
+        /// connection string is obtained by name from the config file based on the connectionstring
+        /// name
+        /// </summary>
+        /// <param name="connectionName">config file connection string name key</param>
+        void ConnectUsingConfig(String connectionName);
+
+        /// <summary>
         /// Connects to the database using a specified database for the user witout a transaction
         /// </summary>
         /// <param name="dataSource">Host (optionally port), machine name or any other data source identifier</param>
@@ -122,7 +141,7 @@ namespace dbfit {
         void ConnectNoTransaction(String dataSource, String username, String password, String database);
 
         /// <summary>
-        /// bind any fixture symbols that match command parameters to this command. 
+        /// bind any fixture symbols that match command parameters to this command.
         /// symbols that have no matching parameters are ignored.
         /// </summary>
         /// <param name="dc"></param>
@@ -137,6 +156,7 @@ namespace dbfit {
         /// Rollback current transaction
         /// </summary>
         void Rollback();
+
         /// <summary>
         /// Retrieve an exception code from a database exception. This method should perform
         /// any required conversion between a .NET exception and the real database error code.
@@ -150,16 +170,17 @@ namespace dbfit {
         /// <param name="updateAccessors">fields that are being modified</param>
         /// <param name="selectAccessors">fields used for selecting affected records</param>
         /// <returns></returns>
-        String BuildUpdateCommand(String tableName, DbParameterAccessor[] updateAccessors, 
+        String BuildUpdateCommand(String tableName, DbParameterAccessor[] updateAccessors,
             DbParameterAccessor[] selectAccessors);
+
         /// <summary>
         /// Accessor for the current database connection, used by DBFit Fixtures
         /// </summary>
         DbConnection CurrentConnection { get; }
+
         /// <summary>
         /// Accessor for the current database transaction, used by DBFit Fixtures
         /// </summary>
         DbTransaction CurrentTransaction { get; }
-
     }
 }

--- a/source/dbfit/fixture/DatabaseTest.cs
+++ b/source/dbfit/fixture/DatabaseTest.cs
@@ -3,15 +3,14 @@
 // This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
-using System;
-using System.Data;
-using System.Data.Common;
 using dbfit.fixture;
 using dbfit.util;
 using fit;
-
 using fitlibrary;
 using fitSharp.Machine.Engine;
+using System;
+using System.Data;
+using System.Data.Common;
 
 namespace dbfit
 {
@@ -19,11 +18,13 @@ namespace dbfit
     {
         protected IDbEnvironment environment;
 
-        public void SetUp() {
+        public void SetUp()
+        {
             util.Options.reset();
         }
 
-        public void TearDown() {
+        public void TearDown()
+        {
             environment.CloseConnection();
         }
 
@@ -51,6 +52,12 @@ namespace dbfit
         {
             environment.ConnectUsingFile(path);
         }
+
+        public void ConnectUsingConfig(String configName)
+        {
+            environment.ConnectUsingConfig(configName);
+        }
+
         public void Close()
         {
             environment.CloseConnection();
@@ -176,7 +183,7 @@ namespace dbfit
             return GetDataTable(symbols, query, environment, 1);
         }
 
-        public static DataTable GetDataTable(Symbols symbols, String query,IDbEnvironment environment, int rsNo)
+        public static DataTable GetDataTable(Symbols symbols, String query, IDbEnvironment environment, int rsNo)
         {
             DbCommand dc = environment.CreateCommand(query, CommandType.Text);
             if (Options.ShouldBindSymbols())

--- a/source/dbfitTest/dbfitTest.csproj
+++ b/source/dbfitTest/dbfitTest.csproj
@@ -76,6 +76,9 @@
       <Name>fit</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/source/fitSharpTest/fitSharpTest.csproj
+++ b/source/fitSharpTest/fitSharpTest.csproj
@@ -135,7 +135,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/source/fitTest/fitTest.csproj
+++ b/source/fitTest/fitTest.csproj
@@ -150,6 +150,9 @@
       <Name>Samples</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Allows users to connect via a config file to DB

eg

!|DatabaseEnvironment|SQLSERVER|
|ConnectUsingConfig|CONNECTIONNAME1|

<connectionStrings>
<add name="CONNECTIONNAME1" connectionString="Data
Source=DBNAME_A;Initial Catalog=CATALOG_A;User
Id=USER;password=PASSWORD;Application Name=APPNAME_A"
providerName="System.Data.SqlClient" />
<add name="CONNECTIONNAME2" connectionString="Data
Source=DBNAME_B;Initial Catalog=CATALOG_B;User
Id=USER;password=PASSWORD;Application Name=APPNAME_B"
providerName="System.Data.SqlClient" />
</connectionStrings>