### PR TITLE
dbFit update missing fixture x2 and add new one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ document/FitnesseRoot/RecentChanges/
 document/FitnesseRoot/files/testResults/
 nuget/lib/
 /packages/
+/.vs/fitSharp/v15/Server/sqlite3

--- a/source/dbfit/dbfit.csproj
+++ b/source/dbfit/dbfit.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" 
-  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -53,6 +52,7 @@
     <Compile Include="fixture\Inspect.cs" />
     <Compile Include="fixture\Query.cs" />
     <Compile Include="fixture\QueryStats.cs" />
+    <Compile Include="fixture\SetTableParameter.cs" />
     <Compile Include="fixture\SetParameter.cs" />
     <Compile Include="fixture\StoreQuery.cs" />
     <Compile Include="fixture\Update.cs" />
@@ -65,6 +65,7 @@
     <Compile Include="util\IdRetrievalAccessor.cs" />
     <Compile Include="util\NameNormaliser.cs" />
     <Compile Include="util\Options.cs" />
+    <Compile Include="util\TableTypeParameter.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\fitSharp\fitSharp.csproj">

--- a/source/dbfit/dbfit.csproj
+++ b/source/dbfit/dbfit.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" 
+  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -42,9 +43,11 @@
     <Compile Include="environment\DbEnvironmentFactory.cs" />
     <Compile Include="fixture\Clean.cs" />
     <Compile Include="fixture\CompareStoredQueries.cs" />
+    <Compile Include="fixture\CompareStoredQueriesHideMatchingRows.cs" />
     <Compile Include="fixture\DatabaseEnvironment.cs" />
     <Compile Include="fixture\DatabaseTest.cs" />
     <Compile Include="fixture\Execute.cs" />
+    <Compile Include="fixture\ExecuteDDL.cs" />
     <Compile Include="fixture\ExecuteProcedure.cs" />
     <Compile Include="fixture\Insert.cs" />
     <Compile Include="fixture\Inspect.cs" />
@@ -79,9 +82,6 @@
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
+  <Target Name="BeforeBuild"></Target><Target Name="AfterBuild"></Target>
   -->
 </Project>

--- a/source/dbfit/environment/DbEnvironment.cs
+++ b/source/dbfit/environment/DbEnvironment.cs
@@ -64,7 +64,7 @@ namespace dbfit {
         /// <param name="statement">Command text to execute</param>
         /// <param name="commandType">Statement type</param>
         /// <returns>initialised DbCommand object</returns>
-        DbCommand CreateCommand(string statement, CommandType commandType);
+        IDbCommand CreateCommand(string statement, CommandType commandType);
         /// <summary>
         /// Closes the current connection and rolls back any active transactions. The transactions
         /// are automatically rolled back to make tests repeatable.
@@ -131,7 +131,7 @@ namespace dbfit {
         /// symbols that have no matching parameters are ignored.
         /// </summary>
         /// <param name="dc"></param>
-        void BindFixtureSymbols(Symbols symbols, DbCommand dc);
+        void BindFixtureSymbols(Symbols symbols, IDbCommand dc);
 
         /// <summary>
         /// Commit current transaction
@@ -160,11 +160,11 @@ namespace dbfit {
         /// <summary>
         /// Accessor for the current database connection, used by DBFit Fixtures
         /// </summary>
-        DbConnection CurrentConnection { get; }
+        IDbConnection CurrentConnection { get; }
         /// <summary>
         /// Accessor for the current database transaction, used by DBFit Fixtures
         /// </summary>
-        DbTransaction CurrentTransaction { get; }
+        IDbTransaction CurrentTransaction { get; }
 
     }
 }

--- a/source/dbfit/fixture/Clean.cs
+++ b/source/dbfit/fixture/Clean.cs
@@ -58,14 +58,14 @@ namespace dbfit.fixture {
 
         private bool hadRowOperation=false;		
 		public bool clean() {
-            DbCommand command = environment.CreateCommand(
+            DbCommand command = (DbCommand)environment.CreateCommand(
                 "Delete from " + table +(where!=null?" where "+where:""), CommandType.Text);
             command.ExecuteNonQuery();
 			return true;
 		}
         public bool DeleteRowsForIDs()
         {
-            DbCommand command = environment.CreateCommand(
+            DbCommand command = (DbCommand)environment.CreateCommand(
                 "Delete from " + table + " where "+columnName +" in ("
                 + getIDCSV()+") "+(where != null ? " and " + where : ""), CommandType.Text);
             command.ExecuteNonQuery();
@@ -74,7 +74,7 @@ namespace dbfit.fixture {
         }
         public bool DeleteRowsForKeys()
         {
-            DbCommand command = environment.CreateCommand(
+            DbCommand command = (DbCommand)environment.CreateCommand(
                 "Delete from " + table + " where " + columnName + " in ("
                 + getKeyCSV() + ") " + (where != null ? " and " + where : ""), CommandType.Text);
             command.ExecuteNonQuery();

--- a/source/dbfit/fixture/CompareStoredQueriesHideMatchingRows.cs
+++ b/source/dbfit/fixture/CompareStoredQueriesHideMatchingRows.cs
@@ -1,0 +1,227 @@
+/// Copyright (C) Gojko Adzic 2006-2008 http://gojko.net
+/// Released under GNU GPL 2.0
+using System;
+using System.Collections.Generic;
+using fit;
+using System.Data;
+using dbfit.util;
+using fitSharp.Fit.Model;
+using fitSharp.Machine.Model;
+
+namespace dbfit.fixture
+{
+    /// <summary>
+    /// This fixture compares two DataTable objects and prints out any unmatched rows.
+    /// DataTables are read from Fixture symbols.
+    /// </summary>
+    public class CompareStoredQueriesHideMatchingRows:fit.Fixture
+    {
+        private IDbEnvironment dbEnvironment;
+        private String symbol1;
+        private String symbol2;
+        private DataTable dt1;
+        private DataTable dt2;
+        private String[] columnNames;
+        private bool[] keyProperties;
+        /// <summary>
+        /// Constructor that will use the default environment (from DbEnvironmentFactory) and
+        /// read the DataTable objects to compare from symbols contained in the first 
+        /// two fixture arguments. Intended for use in standalone mode.
+        /// </summary>
+        public CompareStoredQueriesHideMatchingRows()
+        {
+            dbEnvironment = DbEnvironmentFactory.DefaultEnvironment;
+        }
+        /// <summary>
+        /// Constructor that allows the caller to pass an IDbEnvironment instance and two symbol names
+        /// that will be used to retrieve DataTable objects for comparison. Intended for use in flow mode.
+        /// </summary>
+        /// <param name="environment"></param>
+        /// <param name="symbol1">Symbol name for the fixture symbol containing the first DataTable</param>
+        /// <param name="symbol2">Symbol name for the fixture symbol containing the second DataTable</param>
+        public CompareStoredQueriesHideMatchingRows(IDbEnvironment environment, String symbol1, String symbol2)
+        {
+            this.dbEnvironment = environment;
+            this.symbol1 = symbol1;
+            this.symbol2 = symbol2;
+        }
+        private DataTable GetDataTable(String symbolName){
+		    Object o=Symbols.GetValueOrDefault(symbolName, null);
+		    if (o==null) throw new ApplicationException("Cannot load a stored query from "+symbolName+  " - is is empty");
+		    if (o.GetType().Equals(typeof(DataTable))) return (DataTable) o;
+		    throw new ApplicationException("Cannot load stored query from "+symbolName 
+                + " - object type is "+o.GetType().Name);
+	    }
+        private void InitialiseDataTables()
+        {
+            if (symbol1 == null || symbol2 == null)
+            {
+                if (Args.Length < 2) 
+                    throw new ApplicationException("No symbols specified to CompareStoreQueries constructor or argument list");
+                symbol1 = Args[0];
+                symbol2 = Args[1];
+            }
+            if (symbol1.StartsWith("<<")) symbol1 = symbol1.Substring(2);
+            if (symbol2.StartsWith("<<")) symbol2 = symbol2.Substring(2);
+            // tables will be modified during comparison, so better to clone
+            dt1 = GetDataTable(symbol1).Copy();
+            dt2 = GetDataTable(symbol2).Copy();
+        }
+        private void LoadRowStructure(Parse headerRow)
+        {
+            Parse headerCell = headerRow.Parts;
+            int colNum = headerRow.Parts.Size;
+            columnNames = new String[colNum];
+            keyProperties = new bool[colNum];
+            for (int i = 0; i < colNum; i++)
+            {
+                String currentName = headerCell.Text;
+                if (currentName == null) throw new ApplicationException("Column " + i + " does not have a name");
+                currentName = currentName.Trim();
+                if (currentName.Length == 0) throw new ApplicationException("Column " + i + " does not have a name");
+                columnNames[i] = NameNormaliser.NormaliseName(currentName);
+                keyProperties[i] = !currentName.EndsWith("?");
+                headerCell = headerCell.More;
+            }
+        }
+        public override void DoTable(Parse table)
+        {
+		    InitialiseDataTables();		
+		    Parse lastRow=table.Parts.More;
+		    if (lastRow==null){
+			    throw new ApplicationException("Query structure missing from second row");
+		    }
+		    LoadRowStructure(lastRow);
+		    lastRow=ProcessDataTable(dt1,dt2, lastRow, symbol2);
+    		
+		    foreach (DataRow dr in dt2.Rows){
+			    lastRow=AddRow(lastRow, dr, true, " missing from "+symbol1);
+		    }
+	    }
+
+        private String GetStringValue(DataRow dr, String colName)
+        {
+            Object o = dr[colName];
+            if (o == null) return "null";
+            return o.ToString();
+        }
+
+        private Parse AddRow(Parse lastRow, DataRow dr, bool markAsError, String desc)
+        {
+            Parse newRow = new Parse("tr", null, null, null);
+            lastRow.More = newRow;
+            lastRow = newRow;
+            try
+            {
+                Parse firstCell = new Parse("td",
+                        GetStringValue(dr, columnNames[0]), null, null);
+                newRow.Parts = firstCell;
+                if (markAsError)
+                {
+                    firstCell.AddToBody(Fixture.Gray(desc));
+                    this.Wrong(firstCell);
+                }
+                for (int i = 1; i < columnNames.Length; i++)
+                {
+                    Parse nextCell = new Parse("td",
+                            GetStringValue(dr, columnNames[i]), null, null);
+                    firstCell.More = nextCell;
+                    firstCell = nextCell;
+                }
+            }
+            catch (Exception e)
+            {
+                this.Exception(newRow, e);
+            }
+            return lastRow;
+        }
+        private Parse addRow(Parse lastRow, DataRow dr, DataRow dr2)
+        {
+            Parse newRow = new Parse("tr", null, null, null);
+            lastRow.More = newRow;
+            lastRow = newRow;
+            try
+            {
+                String lval = GetStringValue(dr, columnNames[0]);
+                String rval = GetStringValue(dr2, columnNames[0]);
+                Parse firstCell = new Parse("td", lval, null, null);
+                newRow.Parts = firstCell;
+                if (!lval.Equals(rval))
+                {
+                    Wrong(firstCell, rval);
+                }
+                else
+                {
+                    Right(firstCell);
+                }
+                for (int i = 1; i < columnNames.Length; i++)
+                {
+                    lval = GetStringValue(dr, columnNames[i]);
+                    rval = GetStringValue(dr2, columnNames[i]);
+                    Parse nextCell = new Parse("td",
+                            lval, null, null);
+                    firstCell.More = nextCell;
+                    firstCell = nextCell;
+                    if (!lval.Equals(rval))
+                    {
+                        Wrong(firstCell, rval);
+                    }
+                    else
+                    {
+                        Right(firstCell);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Exception(newRow, e);
+            }
+            return lastRow;
+        }
+        private bool IsMatch(DataRow dr, IDictionary<String, Object> matchingMask)
+        {
+           foreach (String key in matchingMask.Keys){
+               object val = matchingMask[key];
+               object drval = dr[key];
+               if (val == null){
+                    if (drval!=null) return false;   
+               }
+               else {
+                   if (!val.Equals(drval)) return false;
+               }                   
+           }
+           return true;
+        }
+        private DataRow FindMatching(DataTable t, IDictionary<String, Object> matchingMask)
+        {
+            foreach (DataRow dr in t.Rows){
+                   if (IsMatch(dr,matchingMask)) return dr;
+            }
+            return null;
+        }
+        private Parse ProcessDataTable(DataTable t1, DataTable t2, Parse lastScreenRow, String queryName)
+        {
+
+            foreach (DataRow dr in t1.Rows)
+            {
+                IDictionary<String, Object> matchingMask = new Dictionary<String, Object>();
+                for (int i = 0; i < keyProperties.Length; i++)
+                {
+                    if (keyProperties[i])
+                        matchingMask[columnNames[i]] = dr[columnNames[i]];
+                }
+                DataRow dr2 = FindMatching(t2, matchingMask);
+                if (dr2 != null)
+                {
+                    //lastScreenRow = addRow(lastScreenRow, dr, dr2);
+                    t2.Rows.Remove(dr2);
+                }
+                else
+                {
+                    lastScreenRow = AddRow(lastScreenRow, dr, true, " missing from " + queryName);
+                }
+            }
+            return lastScreenRow;
+        }
+    }
+}

--- a/source/dbfit/fixture/DatabaseTest.cs
+++ b/source/dbfit/fixture/DatabaseTest.cs
@@ -1,4 +1,4 @@
-// Copyright © 2015 Syterra Software Inc. Includes work Copyright (C) Gojko Adzic 2006-2008 http://gojko.net
+// Copyright ï¿½ 2015 Syterra Software Inc. Includes work Copyright (C) Gojko Adzic 2006-2008 http://gojko.net
 // This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License version 2.
 // This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
@@ -101,6 +101,11 @@ namespace dbfit
             return new Execute(environment, statement);
         }
 
+        public Fixture ExecuteDDL(String statement)
+        {
+            return new ExecuteDDL(environment, statement);
+        }
+
         public Fixture Insert(String table)
         {
             return new Insert(environment, table);
@@ -169,6 +174,11 @@ namespace dbfit
         public Fixture CompareStoredQueries(String symbol1, String symbol2)
         {
             return new CompareStoredQueries(environment, symbol1, symbol2);
+        }
+
+        public Fixture CompareStoredQueriesHideMatchingRows(String symbol1, String symbol2)
+        {
+            return new CompareStoredQueriesHideMatchingRows(environment, symbol1, symbol2);
         }
 
         public void SetOption(String option, String value)

--- a/source/dbfit/fixture/DatabaseTest.cs
+++ b/source/dbfit/fixture/DatabaseTest.cs
@@ -66,6 +66,11 @@ namespace dbfit
             fixture.SetParameter.SetParameterValue(Symbols, name, value);
         }
 
+        public Fixture SetTableParameter(String name, String type)
+        {
+            return new SetTableParameter(environment, Symbols, name, type);
+        }
+
         public void ClearParameters()
         {
             Symbols.Clear();
@@ -193,12 +198,12 @@ namespace dbfit
 
         public static DataTable GetDataTable(Symbols symbols, String query,IDbEnvironment environment, int rsNo)
         {
-            DbCommand dc = environment.CreateCommand(query, CommandType.Text);
+            var dc = environment.CreateCommand(query, CommandType.Text);
             if (Options.ShouldBindSymbols())
                 environment.BindFixtureSymbols(symbols, dc);
 
             DbDataAdapter oap = environment.DbProviderFactory.CreateDataAdapter();
-            oap.SelectCommand = dc;
+            oap.SelectCommand = (DbCommand)dc;
             var ds = new DataSet();
             oap.Fill(ds);
             dc.Dispose();

--- a/source/dbfit/fixture/Execute.cs
+++ b/source/dbfit/fixture/Execute.cs
@@ -23,7 +23,7 @@ namespace dbfit.fixture
         {
             if (String.IsNullOrEmpty(statement))
                 statement = Args[0];
-            using (DbCommand dc = environment.CreateCommand(statement, CommandType.Text))
+            using (DbCommand dc = (DbCommand)environment.CreateCommand(statement, CommandType.Text))
             {
                 if (dbfit.util.Options.ShouldBindSymbols()) 
                     environment.BindFixtureSymbols(Symbols, dc);

--- a/source/dbfit/fixture/ExecuteDDL.cs
+++ b/source/dbfit/fixture/ExecuteDDL.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using fit;
+using System.Data;
+using System.Data.Common;
+namespace dbfit.fixture
+{
+    public class ExecuteDDL:fit.Fixture
+    {
+        private IDbEnvironment environment;
+        private String statement;
+        public ExecuteDDL()
+        {
+            environment = DbEnvironmentFactory.DefaultEnvironment;
+        }
+        public ExecuteDDL(IDbEnvironment environment, String statement)
+        {
+            this.environment = environment;
+            this.statement = statement;
+        }
+        public override void DoRows(Parse rows)
+        {
+            if (String.IsNullOrEmpty(statement))
+                statement = Args[0];
+            using (DbCommand dc = environment.CreateCommand(statement, CommandType.Text))
+            {
+                if (dbfit.util.Options.ShouldBindSymbols()) 
+                    environment.BindFixtureSymbols(Symbols, dc);
+                dc.ExecuteNonQuery();
+                environment.Commit()
+            }
+        }
+    }
+}

--- a/source/dbfit/fixture/ExecuteDDL.cs
+++ b/source/dbfit/fixture/ExecuteDDL.cs
@@ -23,12 +23,9 @@ namespace dbfit.fixture
         {
             if (String.IsNullOrEmpty(statement))
                 statement = Args[0];
-            using (DbCommand dc = environment.CreateCommand(statement, CommandType.Text))
+            using (DbCommand dc = (DbCommand)environment.CreateCommand(statement, CommandType.Text))
             {
-                if (dbfit.util.Options.ShouldBindSymbols()) 
-                    environment.BindFixtureSymbols(Symbols, dc);
                 dc.ExecuteNonQuery();
-                environment.Commit()
             }
         }
     }

--- a/source/dbfit/fixture/ExecuteProcedure.cs
+++ b/source/dbfit/fixture/ExecuteProcedure.cs
@@ -104,7 +104,7 @@ namespace dbfit.fixture
         }
         private void InitCommand()
         {
-            command = dbEnvironment.CreateCommand(procedureName, CommandType.StoredProcedure);
+            command = (DbCommand)dbEnvironment.CreateCommand(procedureName, CommandType.StoredProcedure);
             DbParameterAccessor[] sortedAccessors = SortAccessors(accessors);
 
             foreach (DbParameterAccessor accessor in sortedAccessors)

--- a/source/dbfit/fixture/Insert.cs
+++ b/source/dbfit/fixture/Insert.cs
@@ -56,7 +56,7 @@ namespace dbfit.fixture {
 		}
 		private void InitCommand() {
             String insert = dbEnvironment.BuildInsertCommand(tableName, accessors);
-            command = dbEnvironment.CreateCommand(insert,
+            command = (DbCommand)dbEnvironment.CreateCommand(insert,
                     CommandType.Text);
             foreach (DbParameterAccessor accessor in accessors) {
                   command.Parameters.Add(accessor.DbParameter);

--- a/source/dbfit/fixture/Inspect.cs
+++ b/source/dbfit/fixture/Inspect.cs
@@ -58,7 +58,7 @@ namespace dbfit.fixture
 		    addRowWithParamNames(table,allParams);
 	    }
 	    private void InspectQuery(Parse table) {
-            DbCommand dc = environment.CreateCommand(objectName, CommandType.Text);
+            DbCommand dc = (DbCommand)environment.CreateCommand(objectName, CommandType.Text);
             environment.BindFixtureSymbols(Symbols, dc);
 
             DbDataAdapter oap = environment.DbProviderFactory.CreateDataAdapter();

--- a/source/dbfit/fixture/QueryStats.cs
+++ b/source/dbfit/fixture/QueryStats.cs
@@ -36,14 +36,14 @@ namespace dbfit.fixture
             if (Query == null)
             {
                 Query = "select count(*) from " + TableName + (Where != null ? " where " + Where : "");
-                DbCommand dc = environment.CreateCommand(Query, CommandType.Text);
+                DbCommand dc = (DbCommand)environment.CreateCommand(Query, CommandType.Text);
                 object o=dc.ExecuteScalar();
                 dc.Dispose();
                 if (o != null) _rows = Convert.ToInt32(o);
             }
             else
             {
-                DbCommand dc = environment.CreateCommand(Query, CommandType.Text);
+                DbCommand dc = (DbCommand)environment.CreateCommand(Query, CommandType.Text);
                 environment.BindFixtureSymbols(Symbols, dc);
 
                 DbDataAdapter oap = environment.DbProviderFactory.CreateDataAdapter();

--- a/source/dbfit/fixture/SetTableParameter.cs
+++ b/source/dbfit/fixture/SetTableParameter.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+
+using fit;
+using dbfit.util;
+using fitSharp.Fit.Operators;
+using fitSharp.Fit.Service;
+using fitSharp.Machine.Engine;
+
+namespace dbfit.fixture
+{
+    public class SetTableParameter : ColumnFixture, MemberQueryable
+    {
+        private readonly IDbEnvironment dbEnvironment;
+        private String parameterTableName;
+        private String parameterTableType;
+        private Symbols symbols;
+
+        private DbParameterAccessor[] accessors;
+        private ColumnAccessors columnAccessors;
+        private bool[] isOutputColumn;
+        private DataTable table;
+
+        public SetTableParameter()
+        {
+            dbEnvironment = DbEnvironmentFactory.DefaultEnvironment;
+        }
+        public SetTableParameter(IDbEnvironment dbEnvironment)
+        {
+            this.dbEnvironment = dbEnvironment;
+        }
+        public SetTableParameter(IDbEnvironment dbEnvironment, Symbols symbols, String parameterTableName, String parameterTableType)
+        {
+            this.parameterTableName = parameterTableName;
+            this.parameterTableType = parameterTableType;
+            this.dbEnvironment = dbEnvironment;
+            this.symbols = symbols;
+            table = new DataTable();
+        }
+
+        public override void DoRows(Parse rows)
+        {
+            if (String.IsNullOrEmpty(parameterTableName) && Args.Length > 0)
+            {
+                parameterTableName = Args[0];
+            }
+            else if (parameterTableName == null)
+            {
+                parameterTableName = rows.Parts.Text;
+                rows = rows.More;
+            }
+            InitParameters(rows.Parts);
+            
+            symbols.Save(parameterTableName, new TableTypeParameter(parameterTableType, table));
+
+            base.DoRows(rows);
+        }
+        public override void DoRow(Parse row)
+        {
+            HasExecuted = false;
+            try
+            {
+                Reset();
+                base.DoRow(row);
+                if (!HasExecuted)
+                {
+                    var CurrentRow = table.NewRow();
+                    foreach (DbParameterAccessor accessor in accessors)
+                    {
+                        CurrentRow[accessor.DbParameter.ParameterName] = accessor.DbParameter.Value;
+                    }
+                    table.Rows.Add(CurrentRow);
+                }                    
+            }
+            catch (Exception e)
+            {
+                TestStatus.MarkException(row.Leaf, e);
+            }
+        }
+
+        // this method will initialise accessors array from the parameters that
+        // really go into the insert command and columnAccessors for all columns
+        private void InitParameters(Parse headerCells)
+        {
+            Dictionary<String, DbParameterAccessor> allParams =
+                dbEnvironment.GetAllColumns(parameterTableType);
+            columnAccessors = new ColumnAccessors();
+            isOutputColumn = new bool[headerCells.Size];
+            var paramAccessors = new List<DbParameterAccessor>();
+            for (int i = 0; headerCells != null; i++, headerCells = headerCells.More)
+            {
+                String paramName = NameNormaliser.NormaliseName(headerCells.Text);
+                DbParameterAccessor currentColumn;
+                try
+                {
+                    currentColumn = allParams[paramName];
+                }
+                catch (KeyNotFoundException)
+                {
+                    Wrong(headerCells);
+                    throw new ApplicationException("Cannot find column " + paramName);
+                }
+                isOutputColumn[i] = BindingFactory.CheckIsImpliedBy(headerCells.Text);
+                currentColumn.IsBoundToCheckOperation = isOutputColumn[i];
+                columnAccessors.Assign(paramName, currentColumn);
+                if (isOutputColumn[i])
+                {
+                    if (dbEnvironment.SupportsReturnOnInsert)
+                    {
+                        currentColumn.DbParameter.Direction = ParameterDirection.Output;
+                        paramAccessors.Add(currentColumn);
+                    }
+                    else // don't add to paramAccessors
+                    {
+                        //columnAccessors.Assign(paramName, new IdRetrievalAccessor(dbEnvironment, currentColumn.DotNetType));
+                        columnAccessors.Assign(paramName, new IdRetrievalAccessor(dbEnvironment, currentColumn.DotNetType, parameterTableType));
+                    }
+                }
+                else // not output
+                {
+                    currentColumn.DbParameter.Direction = ParameterDirection.Input;
+                    paramAccessors.Add(currentColumn);
+                }
+
+                table.Columns.Add(currentColumn.DbFieldName, currentColumn.DotNetType);
+            }
+            accessors = paramAccessors.ToArray();
+        }
+
+        public RuntimeMember Find(MemberSpecification specification)
+        {
+            return columnAccessors.Find(specification, accessor => specification.MatchesIdentifierName(accessor.Key));
+        }
+        
+    }
+}

--- a/source/dbfit/fixture/Update.cs
+++ b/source/dbfit/fixture/Update.cs
@@ -54,7 +54,7 @@ namespace dbfit.fixture {
 
 		private void InitCommand() {
 			String ctext=dbEnvironment.BuildUpdateCommand(tableName,updateAccessors,selectAccessors);
-			command = dbEnvironment.CreateCommand(ctext,CommandType.Text);
+			command = (DbCommand)dbEnvironment.CreateCommand(ctext,CommandType.Text);
          foreach (DbParameterAccessor accessor in updateAccessors) {
                 command.Parameters.Add(accessor.DbParameter);
          }

--- a/source/dbfit/util/IdRetrievalAccessor.cs
+++ b/source/dbfit/util/IdRetrievalAccessor.cs
@@ -26,7 +26,7 @@ namespace dbfit.util
             if (environment.SupportsReturnOnInsert)
                 throw new ApplicationException(environment.GetType() + 
                     " supports return on insert, IdRetrievalAccessor should not be used");
-            DbCommand cmd = environment.CreateCommand(environment.IdentitySelectStatement(tableName), CommandType.Text);
+            DbCommand cmd = (DbCommand)environment.CreateCommand(environment.IdentitySelectStatement(tableName), CommandType.Text);
          //   Console.WriteLine(environment.IdentitySelectExpression);
             object value = cmd.ExecuteScalar();
             value=Convert.ChangeType(value, expectedType);

--- a/source/dbfit/util/TableTypeParameter.cs
+++ b/source/dbfit/util/TableTypeParameter.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Data;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace dbfit.util
+{
+    public class TableTypeParameter
+    {
+        String _tabletype;
+        DataTable _datatable;
+
+        public TableTypeParameter(String tabletype, DataTable datatable)
+        {
+            _tabletype = tabletype;
+            _datatable = datatable;
+        }
+
+        public String Tabletype { get { return _tabletype; } }
+
+        public DataTable Datatable { get { return _datatable; }  }
+         
+    }
+}

--- a/source/dbfitMySql/MySqlEnvironment.cs
+++ b/source/dbfitMySql/MySqlEnvironment.cs
@@ -179,8 +179,9 @@ namespace dbfit
 
         private DbDataReader ExecuteParameterQuery(String[] queryParameters, String query)
         {
-            DbCommand dc = CurrentConnection.CreateCommand();
-            dc.Transaction = CurrentTransaction;
+            var cnx = (DbConnection)CurrentConnection;
+            DbCommand dc = cnx.CreateCommand();
+            dc.Transaction = (DbTransaction)CurrentTransaction;
             dc.CommandText = query;
             dc.CommandType = CommandType.Text;
             if (queryParameters.Length == 2)

--- a/source/dbfitOracle/OracleEnvironment.cs
+++ b/source/dbfitOracle/OracleEnvironment.cs
@@ -81,8 +81,9 @@ namespace dbfit {
 		}
 
 		private Dictionary<string, DbParameterAccessor> ReadIntoParams(String[] queryParameters, String query) {
-			DbCommand dc = CurrentConnection.CreateCommand();
-			dc.Transaction = CurrentTransaction;
+            var cnx = (DbConnection)CurrentConnection;
+            DbCommand dc = cnx.CreateCommand();
+			dc.Transaction = (DbTransaction)CurrentTransaction;
 			dc.CommandText = query;
 			dc.CommandType = CommandType.Text;
 			for (int i = 0; i < queryParameters.Length; i++) {

--- a/source/dbfitSqlServer/SqlServer2000Environment.cs
+++ b/source/dbfitSqlServer/SqlServer2000Environment.cs
@@ -73,8 +73,9 @@ namespace dbfit
         private  Dictionary<string, DbParameterAccessor> ReadIntoParams(String query, String objname, String schemaname)
         {
             objname = NameNormaliser.NormaliseName(objname);
-            DbCommand dc = CurrentConnection.CreateCommand();
-            dc.Transaction = CurrentTransaction;
+            var cnx = (DbConnection)CurrentConnection;
+            DbCommand dc = cnx.CreateCommand();
+            dc.Transaction = (DbTransaction)CurrentTransaction;
             dc.CommandText = query;
             dc.CommandType = CommandType.Text;
             AddInput(dc, "@objname", objname);

--- a/source/dbfitSqlServer/SqlServerEnvironment.cs
+++ b/source/dbfitSqlServer/SqlServerEnvironment.cs
@@ -1,4 +1,4 @@
-// Copyright © 2011 Syterra Software Inc. Includes work Copyright (C) Gojko Adzic 2006-2008 http://gojko.net
+// Copyright Â© 2011 Syterra Software Inc. Includes work Copyright (C) Gojko Adzic 2006-2008 http://gojko.net
 // This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License version 2.
 // This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
@@ -65,7 +65,7 @@ namespace dbfit
             @"SELECT c.[name], TYPE_NAME(c.system_type_id) as [Type], c.max_length, 
             0 As is_output, 0 As is_cursor_ref, c.precision, c.scale
             FROM " + dbName + @"sys.columns c 
-            WHERE c.object_id = COALESCE(OBJECT_ID(@objname), (SELECT type_table_object_id FROM Foo.sys.table_types WHERE user_type_id = TYPE_ID(@objname)))
+            WHERE c.object_id = COALESCE(OBJECT_ID(@objname), (SELECT type_table_object_id FROM "+ dbName + @"sys.table_types WHERE user_type_id = TYPE_ID(@objname)))
             ORDER BY column_id" );
         }
 

--- a/source/dbfitSqlServer/SqlServerEnvironment.cs
+++ b/source/dbfitSqlServer/SqlServerEnvironment.cs
@@ -10,6 +10,7 @@ using System.Data.Common;
 using System.Data.SqlClient;
 using System.Text.RegularExpressions;
 using dbfit.util;
+using fitSharp.Machine.Engine;
 
 namespace dbfit
 {
@@ -57,13 +58,15 @@ namespace dbfit
             }
             return "";
         }
-        public override Dictionary<String, DbParameterAccessor> GetAllColumns(String tableOrViewName)
+        public override Dictionary<String, DbParameterAccessor> GetAllColumns(String tableOrViewOrTypeName)
         {
-            string dbName = GetDbName(tableOrViewName);
-            return ReadIntoParams(tableOrViewName,
-            @"select c.[name], TYPE_NAME(c.system_type_id) as [Type], c.max_length, 
+            string dbName = GetDbName(tableOrViewOrTypeName);
+            return ReadIntoParams(tableOrViewOrTypeName,
+            @"SELECT c.[name], TYPE_NAME(c.system_type_id) as [Type], c.max_length, 
             0 As is_output, 0 As is_cursor_ref, c.precision, c.scale
-            from " + dbName + " sys.columns c where c.object_id = OBJECT_ID(@objname) order by column_id" );
+            FROM " + dbName + @"sys.columns c 
+            WHERE c.object_id = COALESCE(OBJECT_ID(@objname), (SELECT type_table_object_id FROM Foo.sys.table_types WHERE user_type_id = TYPE_ID(@objname)))
+            ORDER BY column_id" );
         }
 
         private  Dictionary<string, DbParameterAccessor> ReadIntoParams(String objname, String query)
@@ -76,17 +79,18 @@ namespace dbfit
             {
                 objname = "[" + NameNormaliser.NormaliseName(objname) + "]";
             }
-            DbCommand dc = CurrentConnection.CreateCommand();
-            dc.Transaction = CurrentTransaction;
+            var cnx = (SqlConnection)CurrentConnection;
+            SqlCommand dc = cnx.CreateCommand();
+            dc.Transaction = (SqlTransaction)CurrentTransaction;
             dc.CommandText = query;
             dc.CommandType = CommandType.Text;
-            AddInput(dc, "@objname", objname);
+            dc.Parameters.Clear();
+            AddInput(dc, "objname", objname);
             DbDataReader reader = dc.ExecuteReader();
             var allParams = new Dictionary<string, DbParameterAccessor>();
             int position=0;
             while (reader.Read())
             {
-
                 String paramName = (reader.IsDBNull(0)) ? null : reader.GetString(0);
                 String dataType = reader.GetString(1);
                 int length = (reader.IsDBNull(2)) ? 0 : Convert.ToInt32(reader[2]);
@@ -126,6 +130,7 @@ namespace dbfit
                     new DbParameterAccessor(dp, GetDotNetType(dataType), position++, dataType);
             }
             reader.Close();
+            dc.Parameters.Clear();
             if (allParams.Count == 0)
                 throw new ApplicationException("Cannot read columns/parameters for object " + objname + " - check spelling or access privileges ");
             return allParams;
@@ -152,6 +157,8 @@ namespace dbfit
         private static readonly string[] VariantTypes = new[] { "SQL_VARIANT" };
         private static readonly string[] FloatTypes = new[] { "FLOAT" };
         private static readonly string[] RealTypes = new[] { "REAL" };
+        private static readonly string[] Structured = new[] { "TABLE TYPE" };
+
         private static string NormaliseTypeName(string dataType)
         {
             dataType = dataType.ToUpper().Trim();
@@ -159,8 +166,7 @@ namespace dbfit
             if (idx >= 0) dataType = dataType.Substring(0, idx);
             idx = dataType.IndexOf("(");
             if (idx >= 0) dataType = dataType.Substring(0, idx);
-            return dataType;
-            
+            return dataType;            
         }
         protected static SqlDbType GetDBType(String dataType)
         { 
@@ -187,8 +193,8 @@ namespace dbfit
             if (Array.IndexOf(VariantTypes, dataType) >= 0) return SqlDbType.Variant;
             if (Array.IndexOf(FloatTypes, dataType) >= 0) return SqlDbType.Float;
             if (Array.IndexOf(RealTypes, dataType) >= 0) return SqlDbType.Real;
-
-
+            if (Array.IndexOf(Structured, dataType) >= 0) return SqlDbType.Structured;
+            
             throw new NotSupportedException("Type " + dataType + " is not supported");
         }
         protected static Type GetDotNetType(String dataType)
@@ -215,8 +221,8 @@ namespace dbfit
             if (Array.IndexOf(FloatTypes, dataType) >= 0) return typeof(double);
             if (Array.IndexOf(RealTypes, dataType) >= 0) return typeof(float);
             if (Array.IndexOf(TimeTypes, dataType) >= 0) return typeof(TimeSpan);
-
-
+            if (Array.IndexOf(Structured, dataType) >= 0) return typeof(DataTable);
+            
             throw new NotSupportedException(".net Type " + dataType + " is not supported");
         }
         private static ParameterDirection GetParameterDirection(int isOutput) {
@@ -245,6 +251,45 @@ namespace dbfit
         protected override string BuildColumnName(string sourceColumnName)
         {
             return "[" + sourceColumnName + "]";
+        }
+
+        protected override void AddInput(IDbCommand dbCommand, String name, Object value)
+        {
+            SqlParameter dbParameter;
+            var cmd = (SqlCommand)dbCommand;
+
+            if (value is TableTypeParameter parameter)
+            {
+                dbParameter = cmd.Parameters.AddWithValue(name, parameter.Datatable );
+                dbParameter.Direction = ParameterDirection.Input;
+                dbParameter.SqlDbType = SqlDbType.Structured ;
+                dbParameter.TypeName = parameter.Tabletype;
+            }
+            else
+            {
+                dbParameter = cmd.Parameters.AddWithValue(name, (value ?? DBNull.Value));
+                dbParameter.Direction = ParameterDirection.Input;
+            }                
+        }
+        public override void BindFixtureSymbols(Symbols symbols, IDbCommand dc)
+        {
+            foreach (String paramName in ExtractParamNames(dc.CommandText))
+            {
+                AddInput(dc, paramName, symbols.GetValueOrDefault(paramName, null));
+            }
+        }
+
+        public override IDbCommand CreateCommand(string statement, CommandType commandType)
+        {
+            if (CurrentConnection == null) throw new ApplicationException("Not connected to database");
+
+            var cnx = (SqlConnection)CurrentConnection;
+            SqlCommand dc = cnx.CreateCommand();
+            dc.CommandText = statement.Replace("\r", " ").Replace("\n", " ");
+            dc.CommandType = commandType;
+            dc.Transaction = (SqlTransaction)CurrentTransaction;
+            dc.CommandTimeout = Options.CommandTimeOut;
+            return dc;
         }
     }
 }

--- a/source/dbfitSybase/SybaseEnvironment.cs
+++ b/source/dbfitSybase/SybaseEnvironment.cs
@@ -42,9 +42,10 @@ namespace dbfit
             get { return paramNames; }
         }
         
-        protected override void AddInput(DbCommand dbCommand, String name, Object value)
+        protected override void AddInput(IDbCommand dbCommand, String name, Object value)
         {
-            DbParameter dbParameter = dbCommand.CreateParameter();
+            var cmd = (DbCommand)dbCommand;
+            DbParameter dbParameter = cmd.CreateParameter();
             dbParameter.Direction = ParameterDirection.Input;
             if (!name.StartsWith(ParameterPrefix))
                 dbParameter.ParameterName = ParameterPrefix + name;
@@ -132,8 +133,9 @@ namespace dbfit
             {
                 objname =  NameNormaliser.NormaliseName(objname) ;
             }
-            DbCommand dc = CurrentConnection.CreateCommand();
-            dc.Transaction = CurrentTransaction;
+            var cnx = (DbConnection)CurrentConnection;
+            DbCommand dc = cnx.CreateCommand();
+            dc.Transaction = (DbTransaction)CurrentTransaction;
             dc.CommandText = query;
             dc.CommandType = CommandType.Text;
             AddInput(dc, "@objname", objname);

--- a/source/dbfitTest/dbfitTest.csproj
+++ b/source/dbfitTest/dbfitTest.csproj
@@ -82,6 +82,9 @@
       <Name>fit</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>xcopy "$(TargetPath)*" "$(SolutionDir)build\$(ConfigurationName)\" /I /Y &amp;

--- a/source/fitSharpTest/fitSharpTest.csproj
+++ b/source/fitSharpTest/fitSharpTest.csproj
@@ -155,7 +155,9 @@
     </None>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>xcopy "$(TargetPath)*" "$(SolutionDir)build\$(ConfigurationName)\" /I /Y &amp;

--- a/source/fitTest/fitTest.csproj
+++ b/source/fitTest/fitTest.csproj
@@ -154,6 +154,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>xcopy "$(TargetPath)*" "$(SolutionDir)build\$(ConfigurationName)\" /I /Y &amp;


### PR DESCRIPTION
Hi, 
I would like to evolve the dbfit part by :
The Implement missing dbfit fixtures
 - ExecuteDDL 
 - CompareQueriesHideMatchingRow 
The Add new fixture 
 - Set Table Parameter (SqlType.Structured for  MSSQL' Table type)

ex : 
!|Execute DDL|!- CREATE TYPE [dbo].[Dictionnary] AS TABLE(	[Key] [varchar](20) NULL,
	[Value] [varchar](255) NULL) -!|
!|Commit|

!|Set Table Parameter| myDict | dbo.Dictionnary |
|Key|Value|
|1|Me|
|2|DbFit|

!|Query|SELECT * FROM @myDict as T|
|Key|Value|
|1|Me|
|2|DbFit|

