### PR TITLE
Make TextReporter serializable

### DIFF
--- a/source/RunnerW/MainForm.cs
+++ b/source/RunnerW/MainForm.cs
@@ -28,6 +28,7 @@ namespace fitSharp.RunnerW {
             textReporter.Write(Environment.NewLine);
         }
 
+        [Serializable]
         class TextReporter: ProgressReporter {
 
             public TextReporter(TextBox text) { this.text = text; }


### PR DESCRIPTION
This change fixes a bug which makes it impossible to actually use RunnerW.

Without this change, the following exception is thrown after clicking 'Go':

`System.Runtime.Serialization.SerializationException: Type 'fitSharp.RunnerW.MainForm+TextReporter' in assembly 'RunnerW, Version=2.6.6621.26674, Culture=neutral, PublicKeyToken=null' is not marked as serializable. at System.AppDomain.CreateInstanceAndUnwrap(String assemblyName, String typeName, Boolean ignoreCase, BindingFlags bindingAttr, Binder binder, Object[] args, CultureInfo culture, Object[] activationAttributes) at fitSharp.Machine.Application.Shell.RunInNewDomain(AppDomainSetup appDomainSetup) at fitSharp.Machine.Application.Shell.RunInDomain(Memory memory) at fitSharp.Machine.Model.Either2.Select[R](Func2 withLeft, Func2 withRight) at fitSharp.Machine.Application.Shell.Run()`