### PR TITLE
Add net5.0-windows target.

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -31,7 +31,7 @@
 
 <Target Name="package">
   <ItemGroup>
-    <NetfxFiles Include="
+    <Netfx462Files Include="
       source\fitSharp\bin\release\net462\fitSharp.dll;
       source\fit\bin\release\net462\fit.dll;
       source\Runner\bin\release\net462\Runner.exe;
@@ -41,6 +41,16 @@
       source\dbfitOracle\bin\release\net462\dbfit.oracle.dll;
       source\dbfitSqlServer\bin\release\net462\dbfit.sqlserver.dll;
       source\dbfitSybase\bin\release\net462\dbfit.sybase.dll;"/>
+    <Netfx48Files Include="
+      source\fitSharp\bin\release\net48\fitSharp.dll;
+      source\fit\bin\release\net48\fit.dll;
+      source\Runner\bin\release\net48\Runner.exe;
+      source\RunnerW\bin\release\net48\RunnerW.exe;
+      source\dbfit\bin\release\net48\dbfit.dll;
+      source\dbfitMySql\bin\release\net48\dbfit.mysql.dll;
+      source\dbfitOracle\bin\release\net48\dbfit.oracle.dll;
+      source\dbfitSqlServer\bin\release\net48\dbfit.sqlserver.dll;
+      source\dbfitSybase\bin\release\net48\dbfit.sybase.dll;"/>
     <NetcoreFiles Include="
       source\fitSharp\bin\release\netcoreapp3.1\fitSharp.dll;
       source\fit\bin\release\netcoreapp3.1\fit.dll;
@@ -65,7 +75,7 @@
       source\dbfitOracle\bin\release\net5.0\dbfit.oracle.dll;
       source\dbfitSqlServer\bin\release\net5.0\dbfit.sqlserver.dll;
       source\dbfitSybase\bin\release\net5.0\dbfit.sybase.dll;"/>
-    <Net5Files Include="
+    <Net5WinFiles Include="
       source\fitSharp\bin\release\net5.0-windows\fitSharp.dll;
       source\fit\bin\release\net5.0-windows\fit.dll;
       source\Runner\bin\release\net5.0-windows\Runner.dll;
@@ -79,10 +89,11 @@
       source\dbfitSybase\bin\release\net5.0-windows\dbfit.sybase.dll;"/>
     <Packages Include="nuget\*.nupkg" />
   </ItemGroup>
-  <Copy SourceFiles="@(NetfxFiles)" DestinationFolder="nuget\lib\net462" />
+  <Copy SourceFiles="@(Netfx462Files)" DestinationFolder="nuget\lib\net462" />
+  <Copy SourceFiles="@(Netfx48Files)" DestinationFolder="nuget\lib\net48" />
   <Copy SourceFiles="@(NetcoreFiles)" DestinationFolder="nuget\lib\netcoreapp3.1" />
   <Copy SourceFiles="@(Net5Files)" DestinationFolder="nuget\lib\net5.0" />
-  <Copy SourceFiles="@(Net5Files)" DestinationFolder="nuget\lib\net5.0-windows" />
+  <Copy SourceFiles="@(Net5WinFiles)" DestinationFolder="nuget\lib\net5.0-windows" />
   <Exec Command="..\binary\tools\nuget\nuget pack FitSharp.nuspec" WorkingDirectory="nuget"/>
   <Move SourceFiles="@(Packages)" DestinationFolder="binary" />
 </Target>

--- a/build.proj
+++ b/build.proj
@@ -65,11 +65,24 @@
       source\dbfitOracle\bin\release\net5.0\dbfit.oracle.dll;
       source\dbfitSqlServer\bin\release\net5.0\dbfit.sqlserver.dll;
       source\dbfitSybase\bin\release\net5.0\dbfit.sybase.dll;"/>
+    <Net5Files Include="
+      source\fitSharp\bin\release\net5.0-windows\fitSharp.dll;
+      source\fit\bin\release\net5.0-windows\fit.dll;
+      source\Runner\bin\release\net5.0-windows\Runner.dll;
+      source\Runner\bin\release\net5.0-windows\Runner.runtimeconfig.json;
+      source\RunnerW\bin\release\net5.0-windows\RunnerW.dll;
+      source\RunnerW\bin\release\net5.0-windows\RunnerW.runtimeconfig.json;
+      source\dbfit\bin\release\net5.0-windows\dbfit.dll;
+      source\dbfitMySql\bin\release\net5.0-windows\dbfit.mysql.dll;
+      source\dbfitOracle\bin\release\net5.0-windows\dbfit.oracle.dll;
+      source\dbfitSqlServer\bin\release\net5.0-windows\dbfit.sqlserver.dll;
+      source\dbfitSybase\bin\release\net5.0-windows\dbfit.sybase.dll;"/>
     <Packages Include="nuget\*.nupkg" />
   </ItemGroup>
   <Copy SourceFiles="@(NetfxFiles)" DestinationFolder="nuget\lib\net462" />
   <Copy SourceFiles="@(NetcoreFiles)" DestinationFolder="nuget\lib\netcoreapp3.1" />
   <Copy SourceFiles="@(Net5Files)" DestinationFolder="nuget\lib\net5.0" />
+  <Copy SourceFiles="@(Net5Files)" DestinationFolder="nuget\lib\net5.0-windows" />
   <Exec Command="..\binary\tools\nuget\nuget pack FitSharp.nuspec" WorkingDirectory="nuget"/>
   <Move SourceFiles="@(Packages)" DestinationFolder="binary" />
 </Target>

--- a/source/Runner/Runner.csproj
+++ b/source/Runner/Runner.csproj
@@ -1,20 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net462;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;net48;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>fitSharp.Runner</RootNamespace>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(TargetFramework)'=='net5.0-windows'">
     <UseWpf>true</UseWpf>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\fitSharp\fitSharp.csproj" />
   </ItemGroup>
-
 </Project>

--- a/source/Runner/Runner.csproj
+++ b/source/Runner/Runner.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net462;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
@@ -6,7 +7,14 @@
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='net5.0-windows'">
+    <UseWpf>true</UseWpf>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\fitSharp\fitSharp.csproj" />
   </ItemGroup>
+
 </Project>

--- a/source/Runner/Runner.csproj
+++ b/source/Runner/Runner.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net462;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>fitSharp.Runner</RootNamespace>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/source/RunnerW/RunnerW.csproj
+++ b/source/RunnerW/RunnerW.csproj
@@ -2,18 +2,16 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net462;net5.0-windows;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;net48;net5.0-windows;netcoreapp3.1</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <RootNamespace>fitSharp.RunnerW</RootNamespace>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(TargetFramework)'=='net5.0-windows'">
     <UseWpf>true</UseWpf>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\fitSharp\fitSharp.csproj" />
   </ItemGroup>

--- a/source/RunnerW/RunnerW.csproj
+++ b/source/RunnerW/RunnerW.csproj
@@ -9,6 +9,11 @@
     <RootNamespace>fitSharp.RunnerW</RootNamespace>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)'=='net5.0-windows'">
+    <UseWpf>true</UseWpf>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\fitSharp\fitSharp.csproj" />
   </ItemGroup>

--- a/source/Samples/Samples.csproj
+++ b/source/Samples/Samples.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;net48;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>fitSharp.Samples</RootNamespace>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/source/Samples/Samples.csproj
+++ b/source/Samples/Samples.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>fitSharp.Samples</RootNamespace>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/source/StoryTest/StoryTest.csproj
+++ b/source/StoryTest/StoryTest.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <RootNamespace>fitSharp.StoryTest</RootNamespace>
-        <TargetFrameworks>net462;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net462;net48;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
         <Deterministic>false</Deterministic>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     </PropertyGroup>

--- a/source/StoryTest/StoryTest.csproj
+++ b/source/StoryTest/StoryTest.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <RootNamespace>fitSharp.StoryTest</RootNamespace>
-        <TargetFrameworks>net462;net5.0;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net462;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
         <Deterministic>false</Deterministic>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     </PropertyGroup>

--- a/source/TestTarget/TestTarget.csproj
+++ b/source/TestTarget/TestTarget.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;net48;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>fitSharp.TestTarget</RootNamespace>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/source/TestTarget/TestTarget.csproj
+++ b/source/TestTarget/TestTarget.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>fitSharp.TestTarget</RootNamespace>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/source/TestTarget2/TestTarget2.csproj
+++ b/source/TestTarget2/TestTarget2.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>fitSharp.TestTarget2</RootNamespace>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/source/TestTarget2/TestTarget2.csproj
+++ b/source/TestTarget2/TestTarget2.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;net48;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>fitSharp.TestTarget2</RootNamespace>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/source/dbfit/dbfit.csproj
+++ b/source/dbfit/dbfit.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>dbfit</RootNamespace>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/source/dbfit/dbfit.csproj
+++ b/source/dbfit/dbfit.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;net48;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>dbfit</RootNamespace>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/source/dbfitMySql/dbfitMySql.csproj
+++ b/source/dbfitMySql/dbfitMySql.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;net48;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>dbfit.MySql</RootNamespace>
     <AssemblyName>dbfit.MySql</AssemblyName>
     <Deterministic>false</Deterministic>

--- a/source/dbfitMySql/dbfitMySql.csproj
+++ b/source/dbfitMySql/dbfitMySql.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>dbfit.MySql</RootNamespace>
     <AssemblyName>dbfit.MySql</AssemblyName>
     <Deterministic>false</Deterministic>

--- a/source/dbfitOracle/dbfitOracle.csproj
+++ b/source/dbfitOracle/dbfitOracle.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>dbfit.Oracle</RootNamespace>
     <AssemblyName>dbfit.Oracle</AssemblyName>
     <Deterministic>false</Deterministic>

--- a/source/dbfitOracle/dbfitOracle.csproj
+++ b/source/dbfitOracle/dbfitOracle.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;net48;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>dbfit.Oracle</RootNamespace>
     <AssemblyName>dbfit.Oracle</AssemblyName>
     <Deterministic>false</Deterministic>

--- a/source/dbfitSqlServer/dbfitSqlServer.csproj
+++ b/source/dbfitSqlServer/dbfitSqlServer.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>dbfit.SqlServer</RootNamespace>
     <AssemblyName>dbfit.SqlServer</AssemblyName>
     <Deterministic>false</Deterministic>

--- a/source/dbfitSqlServer/dbfitSqlServer.csproj
+++ b/source/dbfitSqlServer/dbfitSqlServer.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;net48;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>dbfit.SqlServer</RootNamespace>
     <AssemblyName>dbfit.SqlServer</AssemblyName>
     <Deterministic>false</Deterministic>

--- a/source/dbfitSybase/dbfitSybase.csproj
+++ b/source/dbfitSybase/dbfitSybase.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;net48;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>dbfit.Sybase</RootNamespace>
     <AssemblyName>dbfit.Sybase</AssemblyName>
     <Deterministic>false</Deterministic>

--- a/source/dbfitSybase/dbfitSybase.csproj
+++ b/source/dbfitSybase/dbfitSybase.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>dbfit.Sybase</RootNamespace>
     <AssemblyName>dbfit.Sybase</AssemblyName>
     <Deterministic>false</Deterministic>

--- a/source/dbfitTest/dbfitTest.csproj
+++ b/source/dbfitTest/dbfitTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net462;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>fitSharp.Test</RootNamespace>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/source/dbfitTest/dbfitTest.csproj
+++ b/source/dbfitTest/dbfitTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net462;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;net48;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>fitSharp.Test</RootNamespace>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/source/fit/fit.csproj
+++ b/source/fit/fit.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/source/fit/fit.csproj
+++ b/source/fit/fit.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;net48;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/source/fitSharp/IO/PathId.cs
+++ b/source/fitSharp/IO/PathId.cs
@@ -7,6 +7,12 @@ using System.Runtime.InteropServices;
 
 namespace fitSharp.IO {
     public class PathId {
+        static PathId()
+        {
+            osName = GetOsName();
+        }
+
+
         public static PathId Parse(string input) { return new PathId(input); }
 
         public static string AsOS(string input) {
@@ -19,13 +25,24 @@ namespace fitSharp.IO {
             return input
                 .Replace(System.IO.Path.DirectorySeparatorChar, '\\');
         }
-        
+
         PathId(string id) { this.id = id; }
 
         public string Path => AsOS(id);
 
-        
-        static readonly string osName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "windows" : "linux";
+        static readonly string osName;
+
         readonly string id;
+        private static string GetOsName()
+        {
+#if NETFRAMEWORK
+            return "windows";
+#endif
+#if NETCOREAPP
+                return RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                           ? "windows"
+                           : "linux";
+#endif
+        }
     }
 }

--- a/source/fitSharp/fitSharp.csproj
+++ b/source/fitSharp/fitSharp.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <TargetFrameworks>net462;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.IO.Compression" Condition="'$(TargetFramework)' == 'net462'" />

--- a/source/fitSharp/fitSharp.csproj
+++ b/source/fitSharp/fitSharp.csproj
@@ -2,13 +2,16 @@
   <PropertyGroup>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <TargetFrameworks>net462;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;net48;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System.IO.Compression" Condition="'$(TargetFramework)' == 'net462'" />
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>C:\Program Files\dotnet\sdk\3.1.102\Microsoft\Microsoft.NET.Build.Extensions\net462\lib\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web" Condition="'$(TargetFramework)' == 'net462'" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">
+    <Reference Include="System.IO.Compression"/>
+    <Reference Include="System.Web"/>
+  </ItemGroup>
+
 </Project>

--- a/source/fitSharpTest/fitSharpTest.csproj
+++ b/source/fitSharpTest/fitSharpTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>fitSharp.Test</RootNamespace>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/source/fitSharpTest/fitSharpTest.csproj
+++ b/source/fitSharpTest/fitSharpTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;net48;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>fitSharp.Test</RootNamespace>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/source/fitTest/fitTest.csproj
+++ b/source/fitTest/fitTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;net48;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>fit.Test</RootNamespace>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -16,7 +16,7 @@
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>
-  <ItemGroup>
-    <Reference Include="System.Web" Condition="'$(TargetFramework)' == 'net462'" />
+  <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">
+    <Reference Include="System.Web"/>
   </ItemGroup>
 </Project>

--- a/source/fitTest/fitTest.csproj
+++ b/source/fitTest/fitTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0;net5.0-windows;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>fit.Test</RootNamespace>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>


### PR DESCRIPTION
This adds the possibility to use fitsharp with `net5.0-windows` assemblies. 

It might be an interesting discussing how special target versions like `net5.0-windows10.0.19041.0` should be handled in the future.