### PR TITLE
Support for net7.0 and net7.0-windows.

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -99,6 +99,28 @@
       source\dbfitOracle\bin\release\net6.0-windows\dbfit.oracle.dll;
       source\dbfitSqlServer\bin\release\net6.0-windows\dbfit.sqlserver.dll;
       source\dbfitSybase\bin\release\net6.0-windows\dbfit.sybase.dll;"/>
+     <Net7Files Include="
+      source\fitSharp\bin\release\net7.0\fitSharp.dll;
+      source\fit\bin\release\net7.0\fit.dll;
+      source\Runner\bin\release\net7.0\Runner.dll;
+      source\Runner\bin\release\net7.0\Runner.runtimeconfig.json;
+      source\dbfit\bin\release\net7.0\dbfit.dll;
+      source\dbfitMySql\bin\release\net7.0\dbfit.mysql.dll;
+      source\dbfitOracle\bin\release\net7.0\dbfit.oracle.dll;
+      source\dbfitSqlServer\bin\release\net7.0\dbfit.sqlserver.dll;
+      source\dbfitSybase\bin\release\net7.0\dbfit.sybase.dll;"/>
+     <Net7WinFiles Include="
+      source\fitSharp\bin\release\net7.0-windows\fitSharp.dll;
+      source\fit\bin\release\net7.0-windows\fit.dll;
+      source\Runner\bin\release\net7.0-windows\Runner.dll;
+      source\Runner\bin\release\net7.0-windows\Runner.runtimeconfig.json;
+      source\RunnerW\bin\release\net7.0-windows\RunnerW.dll;
+      source\RunnerW\bin\release\net7.0-windows\RunnerW.runtimeconfig.json;
+      source\dbfit\bin\release\net7.0-windows\dbfit.dll;
+      source\dbfitMySql\bin\release\net7.0-windows\dbfit.mysql.dll;
+      source\dbfitOracle\bin\release\net7.0-windows\dbfit.oracle.dll;
+      source\dbfitSqlServer\bin\release\net7.0-windows\dbfit.sqlserver.dll;
+      source\dbfitSybase\bin\release\net7.0-windows\dbfit.sybase.dll;"/>
    <Packages Include="nuget\*.nupkg" />
   </ItemGroup>
   <Copy SourceFiles="@(Netfx48Files)" DestinationFolder="nuget\lib\net48" />
@@ -107,6 +129,8 @@
   <Copy SourceFiles="@(Net5WinFiles)" DestinationFolder="nuget\lib\net5.0-windows" />
   <Copy SourceFiles="@(Net6Files)" DestinationFolder="nuget\lib\net6.0" />
   <Copy SourceFiles="@(Net6WinFiles)" DestinationFolder="nuget\lib\net6.0-windows" />
+  <Copy SourceFiles="@(Net7Files)" DestinationFolder="nuget\lib\net7.0" />
+  <Copy SourceFiles="@(Net7WinFiles)" DestinationFolder="nuget\lib\net7.0-windows" />
   <Exec Command="..\binary\tools\nuget\nuget pack FitSharp.nuspec" WorkingDirectory="nuget"/>
   <Move SourceFiles="@(Packages)" DestinationFolder="binary" />
 </Target>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "7.0.100",
+    "rollForward": "latestMinor"
+  }
+}

--- a/source/Runner/Runner.csproj
+++ b/source/Runner/Runner.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net48;net5.0;net5.0-windows;netcoreapp3.1;net6.0;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net5.0;net5.0-windows;netcoreapp3.1;net6.0;net6.0-windows;net7.0;net7.0-windows</TargetFrameworks>
     <RootNamespace>fitSharp.Runner</RootNamespace>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/source/Runner/Runner.csproj
+++ b/source/Runner/Runner.csproj
@@ -6,7 +6,7 @@
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)'=='net5.0-windows'">
+  <PropertyGroup Condition="'$(TargetFramework.Contains(-windows))'">
     <UseWpf>true</UseWpf>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>

--- a/source/RunnerW/RunnerW.csproj
+++ b/source/RunnerW/RunnerW.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <OutputType>WinExe</OutputType>
+    <OutputType>Exe</OutputType>
     <TargetFrameworks>net48;net5.0-windows;netcoreapp3.1;net6.0-windows;net7.0-windows</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <RootNamespace>fitSharp.RunnerW</RootNamespace>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)'=='net5.0-windows'">
+  <PropertyGroup Condition="'$(TargetFramework.Contains(-windows))'">
     <UseWpf>true</UseWpf>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>

--- a/source/RunnerW/RunnerW.csproj
+++ b/source/RunnerW/RunnerW.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net48;net5.0-windows;netcoreapp3.1;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net5.0-windows;netcoreapp3.1;net6.0-windows;net7.0-windows</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/source/Samples/Samples.csproj
+++ b/source/Samples/Samples.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;net5.0;net5.0-windows;netcoreapp3.1;net6.0;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net5.0;net5.0-windows;netcoreapp3.1;net6.0;net6.0-windows;net7.0;net7.0-windows</TargetFrameworks>
     <RootNamespace>fitSharp.Samples</RootNamespace>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/source/StoryTest/StoryTest.csproj
+++ b/source/StoryTest/StoryTest.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <RootNamespace>fitSharp.StoryTest</RootNamespace>
-        <TargetFrameworks>net48;net5.0;net5.0-windows;netcoreapp3.1;net6.0;net6.0-windows</TargetFrameworks>
+        <TargetFrameworks>net48;net5.0;net5.0-windows;netcoreapp3.1;net6.0;net6.0-windows;net7.0;net7.0-windows</TargetFrameworks>
         <Deterministic>false</Deterministic>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     </PropertyGroup>

--- a/source/TestTarget/TestTarget.csproj
+++ b/source/TestTarget/TestTarget.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;net5.0;net5.0-windows;netcoreapp3.1;net6.0;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net5.0;net5.0-windows;netcoreapp3.1;net6.0;net6.0-windows;net7.0;net7.0-windows</TargetFrameworks>
     <RootNamespace>fitSharp.TestTarget</RootNamespace>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/source/TestTarget2/TestTarget2.csproj
+++ b/source/TestTarget2/TestTarget2.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;net5.0;net5.0-windows;netcoreapp3.1;net6.0;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net5.0;net5.0-windows;netcoreapp3.1;net6.0;net6.0-windows;net7.0;net7.0-windows</TargetFrameworks>
     <RootNamespace>fitSharp.TestTarget2</RootNamespace>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/source/dbfit/dbfit.csproj
+++ b/source/dbfit/dbfit.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;net5.0;net5.0-windows;netcoreapp3.1;net6.0;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net5.0;net5.0-windows;netcoreapp3.1;net6.0;net6.0-windows;net7.0;net7.0-windows</TargetFrameworks>
     <RootNamespace>dbfit</RootNamespace>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/source/dbfitMySql/dbfitMySql.csproj
+++ b/source/dbfitMySql/dbfitMySql.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;net5.0;net5.0-windows;netcoreapp3.1;net6.0;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net5.0;net5.0-windows;netcoreapp3.1;net6.0;net6.0-windows;net7.0;net7.0-windows</TargetFrameworks>
     <RootNamespace>dbfit.MySql</RootNamespace>
     <AssemblyName>dbfit.MySql</AssemblyName>
     <Deterministic>false</Deterministic>

--- a/source/dbfitOracle/dbfitOracle.csproj
+++ b/source/dbfitOracle/dbfitOracle.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;net5.0;net5.0-windows;netcoreapp3.1;net6.0;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net5.0;net5.0-windows;netcoreapp3.1;net6.0;net6.0-windows;net7.0;net7.0-windows</TargetFrameworks>
     <RootNamespace>dbfit.Oracle</RootNamespace>
     <AssemblyName>dbfit.Oracle</AssemblyName>
     <Deterministic>false</Deterministic>

--- a/source/dbfitSqlServer/dbfitSqlServer.csproj
+++ b/source/dbfitSqlServer/dbfitSqlServer.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;net5.0;net5.0-windows;netcoreapp3.1;net6.0;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net5.0;net5.0-windows;netcoreapp3.1;net6.0;net6.0-windows;net7.0;net7.0-windows</TargetFrameworks>
     <RootNamespace>dbfit.SqlServer</RootNamespace>
     <AssemblyName>dbfit.SqlServer</AssemblyName>
     <Deterministic>false</Deterministic>

--- a/source/dbfitSybase/dbfitSybase.csproj
+++ b/source/dbfitSybase/dbfitSybase.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net5.0;net5.0-windows;netcoreapp3.1;net6.0;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net5.0;net5.0-windows;netcoreapp3.1;net6.0;net6.0-windows;net7.0;net7.0-windows</TargetFrameworks>
     <RootNamespace>dbfit.Sybase</RootNamespace>
     <AssemblyName>dbfit.Sybase</AssemblyName>
     <Deterministic>false</Deterministic>

--- a/source/dbfitTest/dbfitTest.csproj
+++ b/source/dbfitTest/dbfitTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net48;net5.0;net5.0-windows;netcoreapp3.1;net6.0;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net5.0;net5.0-windows;netcoreapp3.1;net6.0;net6.0-windows;net7.0;net7.0-windows</TargetFrameworks>
     <RootNamespace>fitSharp.Test</RootNamespace>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/source/fit/fit.csproj
+++ b/source/fit/fit.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;net5.0;net5.0-windows;netcoreapp3.1;net6.0;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net5.0;net5.0-windows;netcoreapp3.1;net6.0;net6.0-windows;net7.0;net7.0-windows</TargetFrameworks>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/source/fitSharp/fitSharp.csproj
+++ b/source/fitSharp/fitSharp.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <TargetFrameworks>net48;net5.0;net5.0-windows;netcoreapp3.1;net6.0;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net5.0;net5.0-windows;netcoreapp3.1;net6.0;net6.0-windows;net7.0;net7.0-windows</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/source/fitSharp/fitSharp.csproj
+++ b/source/fitSharp/fitSharp.csproj
@@ -9,6 +9,10 @@
       <HintPath>C:\Program Files\dotnet\sdk\3.1.102\Microsoft\Microsoft.NET.Build.Extensions\net462\lib\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
     </Reference>
   </ItemGroup>
+  <PropertyGroup Condition="'$(TargetFramework.Contains(-windows))'">
+    <UseWpf>true</UseWpf>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">
     <Reference Include="System.IO.Compression"/>
     <Reference Include="System.Web"/>

--- a/source/fitSharpTest/fitSharpTest.csproj
+++ b/source/fitSharpTest/fitSharpTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;net5.0;net5.0-windows;netcoreapp3.1;net6.0;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net5.0;net5.0-windows;netcoreapp3.1;net6.0;net6.0-windows;net7.0;net7.0-windows</TargetFrameworks>
     <RootNamespace>fitSharp.Test</RootNamespace>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/source/fitTest/fitTest.csproj
+++ b/source/fitTest/fitTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;net5.0;net5.0-windows;netcoreapp3.1;net6.0;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net5.0;net5.0-windows;netcoreapp3.1;net6.0;net6.0-windows;net7.0;net7.0-windows</TargetFrameworks>
     <RootNamespace>fit.Test</RootNamespace>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>


### PR DESCRIPTION
With the release of Dotnet 7.0 RC1 I thought it would be a good time to start working on the related fitsharp version. As dotnet iterations brought major perormance improvements in the past, I'd like to upgrade some apps as soon it is release.
For this to work I need fitsharp to support it.

In addition to adding net7.0 and net7.0-windows to all projects I also added UseWpf and UseWindowsForms to the the Fitsharp assembly in the net*-windows use cases. This is needed because it is the assembly loading alle the SUT-assemblies and as soon as one of those needs WPF or WinForms APIs it does not work anymore.